### PR TITLE
Update to geojs 0.6.0-rc1.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,7 +36,7 @@ module.exports = function (grunt) {
                 pnltri: '<%= plugin.large_image.geojs_modules %>/pnltri/pnltri.js',
                 proj4: '<%= plugin.large_image.geojs_components %>/proj4/dist/proj4-src.js',
                 d3: '<%= plugin.large_image.geojs_components %>/d3/d3.js',
-                glmatrix: '<%= plugin.large_image.geojs_components %>/gl-matrix/gl-matrix.js'
+                glmatrix: '<%= plugin.large_image.geojs_components %>/gl-matrix/dist/gl-matrix.js'
             }
         },
         uglify: {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/DigitalSlideArchive/large_image.git"
   },
   "dependencies": {
-    "geojs": "0.5.0"
+    "geojs": "0.6.0-rc.1"
   },
   "devDependencies": {},
   "scripts": {}

--- a/web_client/js/imageViewerWidget/geojs.js
+++ b/web_client/js/imageViewerWidget/geojs.js
@@ -18,16 +18,34 @@ girder.views.GeojsImageViewerWidget = girder.views.ImageViewerWidget.extend({
         }
 
         // TODO: if a viewer already exists, do we render again?
-
-        this.viewer = geo.map({
-            node: this.el
-        });
-        this.viewer.createLayer('osm', {
+        var w = this.sizeX, h = this.sizeY;
+        // TODO: this.levels and this.tileSize
+        var mapParams = {
+            node: this.el,
+            ingcs: '+proj=longlat +axis=esu',
+            gcs: '+proj=longlat +axis=enu',
+            maxBounds: {left: 0, top: 0, right: w, bottom: h},
+            center: {x: w / 2, y: h / 2},
+            max: Math.ceil(Math.log(Math.max(w, h) / 256) / Math.log(2)),
+            clampBoundsX: true,
+            clampBoundsY: true,
+            zoom: 0
+        };
+        mapParams.unitsPerPixel = Math.pow(2, mapParams.max);
+        this.viewer = geo.map(mapParams);
+        var layerParams = {
             useCredentials: true,
-            // TODO: syntax has changed in the latest GeoJS version
-            //tileUrl: this._getTileUrl('{z}', '{x}', '{y}')
-            tileUrl: this._getTileUrl('<zoom>', '<x>', '<y>')
-        });
+            url: this._getTileUrl('{z}', '{x}', '{y}'),
+            maxLevel: mapParams.max,
+            wrapX: false,
+            wrapY: false,
+            tileOffset: function () {
+                return {x: 0, y: 0};
+            },
+            attribution: '',
+            tileRounding: Math.ceil
+        };
+        this.viewer.createLayer('osm', layerParams);
 
         return this;
     },


### PR DESCRIPTION
For files that have non 256-pixel square tiles, this still needs to be adjusted.