### PR TITLE
Added additional tile test options.

### DIFF
--- a/server/rest.py
+++ b/server/rest.py
@@ -25,7 +25,8 @@ from girder.api.describe import describeRoute, Description
 from girder.api.rest import loadmodel, RestException
 from girder.models.model_base import AccessType
 
-from .tilesource import TestTileSource, TiffGirderTileSource, TileSourceException
+from .tilesource import TestTileSource, TiffGirderTileSource, \
+    TileSourceException
 
 
 class TilesItemResource(Item):
@@ -42,21 +43,20 @@ class TilesItemResource(Item):
         apiRoot.item.route('GET', (':itemId', 'tiles', 'zxy', ':z', ':x', ':y'),
                            self.getTile)
 
-
-    def _loadTileSource(self, itemId):
+    def _loadTileSource(self, itemId, params):
         try:
             if itemId == 'test':
-                tileSource = TestTileSource(256)
+                tileSource = TestTileSource(256, params=params)
             else:
                 # TODO: cache the user / item loading too
-                item = self.model('item').load(id=itemId, level=AccessType.READ,
-                                               user=self.getCurrentUser(), exc=True)
+                item = self.model('item').load(
+                    id=itemId, level=AccessType.READ,
+                    user=self.getCurrentUser(), exc=True)
                 tileSource = TiffGirderTileSource(item)
             return tileSource
         except TileSourceException as e:
             # TODO: sometimes this could be 400
             raise RestException(e.message, code=500)
-
 
     @describeRoute(
         Description('Get large image metadata.')
@@ -66,9 +66,8 @@ class TilesItemResource(Item):
     )
     @access.public
     def getTilesInfo(self, itemId, params):
-        tileSource = self._loadTileSource(itemId)
+        tileSource = self._loadTileSource(itemId, params)
         return tileSource.getMetadata()
-
 
     @describeRoute(
         Description('Create a large image for this item.')
@@ -113,7 +112,6 @@ class TilesItemResource(Item):
             'created': True
         }
 
-
     @describeRoute(
         Description('Remove a large image from this item.')
         .param('itemId', 'The ID of the item.', paramType='path')
@@ -133,13 +131,15 @@ class TilesItemResource(Item):
             'deleted': deleted
         }
 
-
     @describeRoute(
         Description('Get a large image tile.')
         .param('itemId', 'The ID of the item or "test".', paramType='path')
-        .param('z', 'The layer number of the tile (0 is the most zoomed-out layer).', paramType='path')
-        .param('x', 'The X coordinate of the tile (0 is the left side).', paramType='path')
-        .param('y', 'The Y coordinate of the tile (0 is the top).', paramType='path')
+        .param('z', 'The layer number of the tile (0 is the most zoomed-out '
+               'layer).', paramType='path')
+        .param('x', 'The X coordinate of the tile (0 is the left side).',
+               paramType='path')
+        .param('y', 'The Y coordinate of the tile (0 is the top).',
+               paramType='path')
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
@@ -151,11 +151,14 @@ class TilesItemResource(Item):
         except ValueError:
             raise RestException('x, y, and z must be integers', code=400)
 
-        tileSource = self._loadTileSource(itemId)
+        tileSource = self._loadTileSource(itemId, params)
         try:
             tileData = tileSource.getTile(x, y, z)
         except TileSourceException as e:
             raise RestException(e.message, code=404)
 
-        cherrypy.response.headers['Content-Type'] = 'image/jpeg'
+        if tileData[:8] == '\x89PNG\r\n\x26\n':
+            cherrypy.response.headers['Content-Type'] = 'image/png'
+        else:
+            cherrypy.response.headers['Content-Type'] = 'image/jpeg'
         return lambda: tileData

--- a/server/rest.py
+++ b/server/rest.py
@@ -46,7 +46,15 @@ class TilesItemResource(Item):
     def _loadTileSource(self, itemId, params):
         try:
             if itemId == 'test':
-                tileSource = TestTileSource(256, params=params)
+                tileSource = TestTileSource(
+                    minLevel=params.get('minLevel'),
+                    maxLevel=params.get('maxLevel'),
+                    tileWidth=params.get('tileWidth'),
+                    tileHeight=params.get('tileHeight'),
+                    sizeX=params.get('sizeX'),
+                    sizeY=params.get('sizeY'),
+                    fractal=(params.get('fractal') == 'true')
+                )
             else:
                 # TODO: cache the user / item loading too
                 item = self.model('item').load(
@@ -157,8 +165,5 @@ class TilesItemResource(Item):
         except TileSourceException as e:
             raise RestException(e.message, code=404)
 
-        if tileData[:8] == '\x89PNG\r\n\x26\n':
-            cherrypy.response.headers['Content-Type'] = 'image/png'
-        else:
-            cherrypy.response.headers['Content-Type'] = 'image/jpeg'
+        cherrypy.response.headers['Content-Type'] = tileSource.getTileMimeType()
         return lambda: tileData

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -28,23 +28,26 @@ class TileSourceException(Exception):
 
 class TileSource(object):
     def __init__(self):
-        self.tileSize = None
+        self.tileWidth = None
+        self.tileHeight = None
         self.levels = None
         self.sizeX = None
         self.sizeY = None
 
     def getMetadata(self):
         return {
-            'tileSize': self.tileSize,
             'levels': self.levels,
             'sizeX': self.sizeX,
             'sizeY': self.sizeY,
-            'tileWidth': getattr(self, 'tileWidth', self.tileSize),
-            'tileHeight': getattr(self, 'tileHeight', self.tileSize),
+            'tileWidth': self.tileWidth,
+            'tileHeight': self.tileHeight,
         }
 
     def getTile(self, x, y, z):
         raise NotImplementedError()
+
+    def getTileMimeType(self):
+        return 'image/jpeg'
 
 
 class GirderTileSource(TileSource):

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -38,7 +38,9 @@ class TileSource(object):
             'tileSize': self.tileSize,
             'levels': self.levels,
             'sizeX': self.sizeX,
-            'sizeY': self.sizeY
+            'sizeY': self.sizeY,
+            'tileWidth': getattr(self, 'tileWidth', self.tileSize),
+            'tileHeight': getattr(self, 'tileHeight', self.tileSize),
         }
 
     def getTile(self, x, y, z):
@@ -57,14 +59,18 @@ class GirderTileSource(TileSource):
             # don't repeat.
             # TODO: is it possible that the file is on a different item, so do
             # we want to repeat the access check?
-            largeImageFile = ModelImporter.model('file').load(largeImageFileId, force=True)
+            largeImageFile = ModelImporter.model('file').load(
+                largeImageFileId, force=True)
 
             # TODO: can we move some of this logic into Girder core?
-            assetstore = ModelImporter.model('assetstore').load(largeImageFile['assetstoreId'])
+            assetstore = ModelImporter.model('assetstore').load(
+                largeImageFile['assetstoreId'])
             adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
 
-            if not isinstance(adapter, assetstore_utilities.FilesystemAssetstoreAdapter):
-                raise TileSourceException('Non-filesystem assetstores are not supported')
+            if not isinstance(adapter,
+                              assetstore_utilities.FilesystemAssetstoreAdapter):
+                raise TileSourceException(
+                    'Non-filesystem assetstores are not supported')
 
             largeImagePath = adapter.fullPath(largeImageFile)
             return largeImagePath

--- a/server/tilesource/dummy.py
+++ b/server/tilesource/dummy.py
@@ -24,7 +24,8 @@ class DummyTileSource(TileSource):
 
     def __init__(self, *args, **kwargs):
         super(DummyTileSource, self).__init__()
-        self.tileSize = 0
+        self.tileWidth = 0
+        self.tileHeight = 0
         self.levels = 0
         self.sizeX = 0
         self.sizeY = 0

--- a/server/tilesource/test.py
+++ b/server/tilesource/test.py
@@ -35,14 +35,66 @@ from .base import TileSource, TileSourceException
 
 
 class TestTileSource(TileSource):
-    # TODO: move this class to its own file, and only import if PIL v3+ is available
-    def __init__(self, tileSize=256, levels=10):
-        super(TestTileSource, self).__init__()
-        self.tileSize = tileSize
-        self.levels = levels
-        self.sizeX = (2 ** (self.levels - 1)) * self.tileSize
-        self.sizeY = (2 ** (self.levels - 1)) * self.tileSize
+    # TODO: move this class to its own file, and only import if PIL v3+ is
+    # available
+    def __init__(self, tileSize=256, levels=10, params=None):
+        """
+        Initialize the tile class.  The optional params options can include:
+          min: minimum tile level (default 0)
+          max: maximum tile level (default levels - 1)
+          fractal: if 'true', draw a simple fractal on the tiles.
+          w: tile width in pixels (default tileSize)
+          h: tile height in pixels (default tileSize)
+          sizex: image width in pixels at maximum level.
+          sizey: image height in pixels at maximum level.
 
+        :param tileSize: square tile size if not overridden by params.
+        :param levels: number of zoom levels if not overridden by params.  The
+                       allowed zoom levels are [0, levels).
+        :param params: a dictionary of optional parameters.  See above.
+        """
+        super(TestTileSource, self).__init__()
+        self.tileWidth = self.tileHeight = tileSize
+        self.maxlevel = levels - 1
+        self.minlevel = 0
+        self.fractal = False
+        if params:
+            self.minlevel = int(params.get('min', 0))
+            self.maxlevel = int(params.get('max', self.maxlevel))
+            self.fractal = (params.get('fractal') == 'true')
+            self.tileWidth = int(params.get('w', self.tileWidth))
+            self.tileHeight = int(params.get('h', self.tileHeight))
+        self.sizeX = (2 ** self.maxlevel) * self.tileWidth
+        self.sizeY = (2 ** self.maxlevel) * self.tileHeight
+        if params:
+            self.sizeX = int(params.get('sizex', self.sizeX))
+            self.sizeY = int(params.get('sizey', self.sizeY))
+        self.levels = self.maxlevel + 1
+        self.tileSize = max(self.tileWidth, self.tileHeight)
+
+    def fractalTile(self, image, x, y, widthCount, color=(0, 0, 0)):
+        # Don't generate a fractal tile if the tile isn't square or not a power
+        # of 2 in size.
+        if (self.tileWidth != self.tileHeight or
+                (self.tileWidth & (self.tileWidth - 1))):
+            return
+        imageDraw = ImageDraw.Draw(image)
+        x *= self.tileWidth
+        y *= self.tileHeight
+        sq = widthCount * self.tileWidth
+        while sq >= 4:
+            sq1 = sq / 4
+            sq2 = sq1 + sq / 2
+            for t in range(-(y % sq), self.tileWidth, sq):
+                if t + sq1 < self.tileWidth and t + sq2 >= 0:
+                    for l in range(-(x % sq), self.tileWidth, sq):
+                        if l + sq1 < self.tileWidth and l + sq2 >= 0:
+                            imageDraw.rectangle([
+                                max(-1, l + sq1), max(-1, t + sq1),
+                                min(self.tileWidth, l + sq2 - 1),
+                                min(self.tileWidth, t + sq2 - 1),
+                            ], color, None)
+            sq /= 2
 
     def getTile(self, x, y, z):
         widthCount = 2 ** z
@@ -51,7 +103,7 @@ class TestTileSource(TileSource):
             raise TileSourceException('x is outside layer')
         if not (0 <= y < widthCount):
             raise TileSourceException('y is outside layer')
-        if not (0 <= z < self.levels):
+        if not (self.minlevel <= z <= self.maxlevel):
             raise TileSourceException('z layer does not exist')
 
         xFraction = float(x) / (widthCount - 1) if z != 0 else 0
@@ -62,17 +114,23 @@ class TestTileSource(TileSource):
             s=(0.3 + (0.7 * yFraction)),
             v=(0.3 + (0.7 * yFraction)),
         )
+        rgbColor = tuple(int(val * 255) for val in backgroundColor)
 
         image = Image.new(
             mode='RGB',
-            size=(self.tileSize, self.tileSize),
-            color=tuple(int(val * 255) for val in backgroundColor)
+            size=(self.tileWidth, self.tileHeight),
+            color=(rgbColor if not self.fractal else (255, 255, 255))
         )
         imageDraw = ImageDraw.Draw(image)
+
+        if self.fractal:
+            self.fractalTile(image, x, y, widthCount, rgbColor)
+
         try:
+            # the font size should fill the whole tile
             imageDrawFont = ImageFont.truetype(
                 font='/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf',
-                size=int(0.24 * self.tileSize)  # this size fills the whole tile
+                size=int(0.15 * min(self.tileWidth, self.tileHeight))
             )
         except IOError:
             imageDrawFont = ImageFont.load_default()
@@ -84,5 +142,5 @@ class TestTileSource(TileSource):
         )
 
         output = StringIO()
-        image.save(output, 'JPEG')
+        image.save(output, 'PNG')
         return output.getvalue()

--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -370,6 +370,27 @@ class TiledTiffDirectory(object):
         # TODO: fetch lazily and memoize
         return self._tileSize
 
+    @property
+    def tileWidth(self):
+        """
+        Get the pixel width of tiles.
+
+        :return: The tile width in pixels.
+        :rtype: int
+        """
+        # TODO: fetch lazily and memoize
+        return self._tileSize
+
+    @property
+    def tileHeight(self):
+        """
+        Get the pixel height of tiles.
+
+        :return: The tile height in pixels.
+        :rtype: int
+        """
+        # TODO: fetch lazily and memoize
+        return self._tileSize
 
     @property
     def imageWidth(self):

--- a/web_client/js/imageViewerWidget/base.js
+++ b/web_client/js/imageViewerWidget/base.js
@@ -7,7 +7,6 @@ girder.views.ImageViewerWidget = girder.View.extend({
             path: 'item/' + this.itemId + '/tiles'
         }).done(_.bind(function (resp) {
             this.levels = resp.levels;
-            this.tileSize = resp.tileSize;
             this.tileWidth = resp.tileWidth;
             this.tileHeight = resp.tileHeight;
             this.sizeX = resp.sizeX;

--- a/web_client/js/imageViewerWidget/base.js
+++ b/web_client/js/imageViewerWidget/base.js
@@ -8,6 +8,8 @@ girder.views.ImageViewerWidget = girder.View.extend({
         }).done(_.bind(function (resp) {
             this.levels = resp.levels;
             this.tileSize = resp.tileSize;
+            this.tileWidth = resp.tileWidth;
+            this.tileHeight = resp.tileHeight;
             this.sizeX = resp.sizeX;
             this.sizeY = resp.sizeY;
             this.render();

--- a/web_client/js/imageViewerWidget/geojs.js
+++ b/web_client/js/imageViewerWidget/geojs.js
@@ -1,3 +1,4 @@
+/* globals geo */
 girder.views.GeojsImageViewerWidget = girder.views.ImageViewerWidget.extend({
     initialize: function (settings) {
         girder.views.ImageViewerWidget.prototype.initialize.call(this, settings);
@@ -26,13 +27,14 @@ girder.views.GeojsImageViewerWidget = girder.views.ImageViewerWidget.extend({
             gcs: '+proj=longlat +axis=enu',
             maxBounds: {left: 0, top: 0, right: w, bottom: h},
             center: {x: w / 2, y: h / 2},
-            max: Math.ceil(Math.log(Math.max(w, h) / 256) / Math.log(2)),
+            max: Math.ceil(Math.log(Math.max(
+                w / (this.tileWidth || this.tileSize),
+                h / (this.tileHeight || this.tileSize))) / Math.log(2)),
             clampBoundsX: true,
             clampBoundsY: true,
             zoom: 0
         };
         mapParams.unitsPerPixel = Math.pow(2, mapParams.max);
-        this.viewer = geo.map(mapParams);
         var layerParams = {
             useCredentials: true,
             url: this._getTileUrl('{z}', '{x}', '{y}'),
@@ -43,8 +45,11 @@ girder.views.GeojsImageViewerWidget = girder.views.ImageViewerWidget.extend({
                 return {x: 0, y: 0};
             },
             attribution: '',
+            tileWidth: this.tileWidth || this.tileSize,
+            tileHeight: this.tileHeight || this.tileSize,
             tileRounding: Math.ceil
         };
+        this.viewer = geo.map(mapParams);
         this.viewer.createLayer('osm', layerParams);
 
         return this;

--- a/web_client/js/imageViewerWidget/geojs.js
+++ b/web_client/js/imageViewerWidget/geojs.js
@@ -14,7 +14,7 @@ girder.views.GeojsImageViewerWidget = girder.views.ImageViewerWidget.extend({
 
     render: function () {
         // If script or metadata isn't loaded, then abort
-        if (!window.geo || !this.tileSize) {
+        if (!window.geo || !this.tileWidth || !this.tileHeight) {
             return;
         }
 

--- a/web_client/js/imageViewerWidget/leaflet.js
+++ b/web_client/js/imageViewerWidget/leaflet.js
@@ -20,7 +20,7 @@ girder.views.LeafletImageViewerWidget = girder.views.ImageViewerWidget.extend({
         }
 
         if (this.tileWidth !== this.tileHeight) {
-            console.log('The Leaflet viewer only supports square tiles.');
+            console.error('The Leaflet viewer only supports square tiles.');
             return;
         }
 

--- a/web_client/js/imageViewerWidget/leaflet.js
+++ b/web_client/js/imageViewerWidget/leaflet.js
@@ -15,7 +15,12 @@ girder.views.LeafletImageViewerWidget = girder.views.ImageViewerWidget.extend({
 
     render: function () {
         // If script or metadata isn't loaded, then abort
-        if (!window.L || !this.tileSize) {
+        if (!window.L || !this.tileWidth || !this.tileHeight) {
+            return;
+        }
+
+        if (this.tileWidth !== this.tileHeight) {
+            console.log('The Leaflet viewer only supports square tiles.');
             return;
         }
 
@@ -32,7 +37,10 @@ girder.views.LeafletImageViewerWidget = girder.views.ImageViewerWidget.extend({
             ],
             layers: [
                 L.tileLayer(this._getTileUrl('{z}', '{x}', '{y}'), {
-                    tileSize: this.tileSize,
+                    // in theory, tileSize: new L.Point(this.tileWidth,
+                    // this.tileHeight) is supposed to support non-square
+                    // tiles, but it doesn't work
+                    tileSize: this.tileWidth,
                     continuousWorld: true
                 })
             ],

--- a/web_client/js/imageViewerWidget/openlayers.js
+++ b/web_client/js/imageViewerWidget/openlayers.js
@@ -15,7 +15,7 @@ girder.views.OpenlayersImageViewerWidget = girder.views.ImageViewerWidget.extend
 
     render: function () {
         // If script or metadata isn't loaded, then abort
-        if (!window.ol || !this.tileSize) {
+        if (!window.ol || !this.tileWidth || !this.tileHeight) {
             return;
         }
 
@@ -26,8 +26,7 @@ girder.views.OpenlayersImageViewerWidget = girder.views.ImageViewerWidget.extend
             layers: [
                 new ol.layer.Tile({
                     source: new ol.source.XYZ({
-                        tileSize: [this.tileWidth || this.tileSize,
-                                   this.tileHeight || this.tileSize],
+                        tileSize: [this.tileWidth, this.tileHeight],
                         url: this._getTileUrl('{z}', '{x}', '{y}'),
                         crossOrigin: 'use-credentials',
                         maxZoom: this.maxZoom,

--- a/web_client/js/imageViewerWidget/openlayers.js
+++ b/web_client/js/imageViewerWidget/openlayers.js
@@ -26,7 +26,8 @@ girder.views.OpenlayersImageViewerWidget = girder.views.ImageViewerWidget.extend
             layers: [
                 new ol.layer.Tile({
                     source: new ol.source.XYZ({
-                        tileSize: this.tileSize,
+                        tileSize: [this.tileWidth || this.tileSize,
+                                   this.tileHeight || this.tileSize],
                         url: this._getTileUrl('{z}', '{x}', '{y}'),
                         crossOrigin: 'use-credentials',
                         maxZoom: this.maxZoom,

--- a/web_client/js/imageViewerWidget/openseadragon.js
+++ b/web_client/js/imageViewerWidget/openseadragon.js
@@ -12,7 +12,7 @@ girder.views.OpenseadragonImageViewerWidget = girder.views.ImageViewerWidget.ext
 
     render: function () {
         // If script or metadata isn't loaded, then abort
-        if (!window.OpenSeadragon || !this.tileSize) {
+        if (!window.OpenSeadragon || !this.tileWidth || !this.tileHeight) {
             return;
         }
 
@@ -27,8 +27,8 @@ girder.views.OpenseadragonImageViewerWidget = girder.views.ImageViewerWidget.ext
             tileSources: {
                 height: this.sizeY,
                 width: this.sizeX,
-                tileWidth: this.tileWidth || this.tileSize,
-                tileHeight: this.tileHeight || this.tileSize,
+                tileWidth: this.tileWidth,
+                tileHeight: this.tileHeight,
                 minLevel: 0,
                 maxLevel: this.levels - 1,
                 getTileUrl: _.bind(this._getTileUrl, this),

--- a/web_client/js/imageViewerWidget/openseadragon.js
+++ b/web_client/js/imageViewerWidget/openseadragon.js
@@ -27,7 +27,8 @@ girder.views.OpenseadragonImageViewerWidget = girder.views.ImageViewerWidget.ext
             tileSources: {
                 height: this.sizeY,
                 width: this.sizeX,
-                tileSize: this.tileSize,
+                tileWidth: this.tileWidth || this.tileSize,
+                tileHeight: this.tileHeight || this.tileSize,
                 minLevel: 0,
                 maxLevel: this.levels - 1,
                 getTileUrl: _.bind(this._getTileUrl, this),

--- a/web_client/js/imageViewerWidget/slideatlas.js
+++ b/web_client/js/imageViewerWidget/slideatlas.js
@@ -15,7 +15,12 @@ girder.views.SlideAtlasImageViewerWidget = girder.views.ImageViewerWidget.extend
 
     render: function () {
         // If script or metadata isn't loaded, then abort
-        if (!window.SlideAtlas || !this.tileSize) {
+        if (!window.SlideAtlas || !this.tileWidth || !this.tileHeight) {
+            return;
+        }
+
+        if (this.tileWidth !== this.tileHeight) {
+            console.log('The SlideAtlas viewer only supports square tiles.');
             return;
         }
 
@@ -27,14 +32,14 @@ girder.views.SlideAtlasImageViewerWidget = girder.views.ImageViewerWidget.extend
             tileSource  : {
                 height  : this.sizeY,
                 width   : this.sizeX,
-                tileSize: this.tileSize,
+                tileSize: this.tileWidth,
                 minLevel: 0,
                 maxLevel: this.levels - 1,
                 getTileUrl: _.bind(this._getTileUrl, this),
                 ajaxWithCredentials: true
             }});
         this.viewer = this.el.saViewer;
-       
+
 
         return this;
     },

--- a/web_client/js/imageViewerWidget/slideatlas.js
+++ b/web_client/js/imageViewerWidget/slideatlas.js
@@ -20,7 +20,7 @@ girder.views.SlideAtlasImageViewerWidget = girder.views.ImageViewerWidget.extend
         }
 
         if (this.tileWidth !== this.tileHeight) {
-            console.log('The SlideAtlas viewer only supports square tiles.');
+            console.error('The SlideAtlas viewer only supports square tiles.');
             return;
         }
 


### PR DESCRIPTION
Confirmed that this works with non-square tiles (and tiles of any size).

The test tile server now can take a variety of query parameters:
-  min: minimum tile level (default 0)
-  max: maximum tile level (default levels parameter - 1)
-  fractal: if 'true', draw a simple fractal on the tiles (only on square power-of-two tiles)
-  w: tile width in pixels (default tileSize parameter)
-  h: tile height in pixels (default tileSize parameter)
-  sizex: image width in pixels at maximum level.
-  sizey: image height in pixels at maximum level.

The tile size is percolated through to the viewer javascript as tileWidth and tileHeight, if available.  If additional viewers are extended to handle non-square tiles, they should check if these values are set and fall back to tileSize if not.

The following viewers work with non-square tiles:
-  GeoJS
-  OpenLayers
-  OpenSeaDragon

Leaflet claims it supports non-square tiles by using L.Point for the tileSize, but the code which detects retina displays breaks when it encounters this, so it doesn't work as simply as the documentation claims.  I haven't tried to use non-square tiles in SlideAtlas.

Also, autodetect PNGs and send the right mime type for them (otherwise we assume JPGs).  Using PNGs with the fractal tiles looks a lot better than the compression artifacts on JPGs.

I also adjusted some formatting to make it closer to the girder standards.