### PR TITLE
Fix issues with tileSize

### DIFF
--- a/server/rest.py
+++ b/server/rest.py
@@ -46,15 +46,24 @@ class TilesItemResource(Item):
     def _loadTileSource(self, itemId, params):
         try:
             if itemId == 'test':
-                tileSource = TestTileSource(
-                    minLevel=params.get('minLevel'),
-                    maxLevel=params.get('maxLevel'),
-                    tileWidth=params.get('tileWidth'),
-                    tileHeight=params.get('tileHeight'),
-                    sizeX=params.get('sizeX'),
-                    sizeY=params.get('sizeY'),
-                    fractal=(params.get('fractal') == 'true')
-                )
+                tileSourceArgs = {}
+                for paramName, paramType in [
+                    ('minLevel', int),
+                    ('maxLevel', int),
+                    ('tileWidth', int),
+                    ('tileHeight', int),
+                    ('sizeX', int),
+                    ('sizeY', int),
+                    ('fractal', lambda val: val == 'true'),
+                ]:
+                    try:
+                        if paramName in params:
+                            tileSourceArgs[paramName] = \
+                                paramType(params[paramName])
+                    except ValueError:
+                        raise RestException(
+                            '"%s" parameter is an incorrect type.' % paramName)
+                tileSource = TestTileSource(**tileSourceArgs)
             else:
                 # TODO: cache the user / item loading too
                 item = self.model('item').load(

--- a/server/tilesource/test.py
+++ b/server/tilesource/test.py
@@ -36,7 +36,7 @@ from .base import TileSource, TileSourceException
 
 
 class TestTileSource(TileSource):
-    def __init__(self, tileSize=256, minLevel=0, maxLevel=9,
+    def __init__(self, minLevel=0, maxLevel=9,
                  tileWidth=256, tileHeight=256, sizeX=None, sizeY=None,
                  fractal=False, encoding='PNG'):
         """
@@ -44,7 +44,6 @@ class TestTileSource(TileSource):
 
         :param minLevel: minimum tile level
         :param maxLevel: maximum tile level
-        :param tileSize: square tile size if not overridden by w and h.
         :param tileWidth: tile width in pixels
         :param tileHeight: tile height in pixels
         :param sizeX: image width in pixels at maximum level.  Computed from
@@ -57,7 +56,6 @@ class TestTileSource(TileSource):
         """
         super(TestTileSource, self).__init__()
 
-        tileSize = 256 if not tileSize else tileSize
         self.minLevel = minLevel
         self.maxLevel = maxLevel
         self.tileWidth = tileWidth

--- a/server/tilesource/test.py
+++ b/server/tilesource/test.py
@@ -36,17 +36,17 @@ from .base import TileSource, TileSourceException
 
 
 class TestTileSource(TileSource):
-    def __init__(self, tileSize=256, minLevel=None, maxLevel=None,
-                 tileWidth=None, tileHeight=None, sizeX=None, sizeY=None,
+    def __init__(self, tileSize=256, minLevel=0, maxLevel=9,
+                 tileWidth=256, tileHeight=256, sizeX=None, sizeY=None,
                  fractal=False, encoding='PNG'):
         """
         Initialize the tile class.  The optional params options can include:
 
+        :param minLevel: minimum tile level
+        :param maxLevel: maximum tile level
         :param tileSize: square tile size if not overridden by w and h.
-        :param minLevel: minimum tile level (default 0)
-        :param maxLevel: maximum tile level (default 9)
-        :param tileWidth: tile width in pixels (tileSize if None)
-        :param tileHeight: tile height in pixels (tileSize if None)
+        :param tileWidth: tile width in pixels
+        :param tileHeight: tile height in pixels
         :param sizeX: image width in pixels at maximum level.  Computed from
             maxLevel and tileWidth if None.
         :param sizeY: image height in pixels at maximum level.  Computer from
@@ -58,19 +58,21 @@ class TestTileSource(TileSource):
         super(TestTileSource, self).__init__()
 
         tileSize = 256 if not tileSize else tileSize
-        self.maxLevel = 9 if maxLevel is None else int(maxLevel)
-        self.minLevel = 0 if minLevel is None else int(minLevel)
-        self.tileWidth = int(tileSize if tileWidth is None else tileWidth)
-        self.tileHeight = int(tileSize if tileHeight is None else tileHeight)
+        self.minLevel = minLevel
+        self.maxLevel = maxLevel
+        self.tileWidth = tileWidth
+        self.tileHeight = tileHeight
         # Don't generate a fractal tile if the tile isn't square or not a power
         # of 2 in size.
         self.fractal = (fractal and self.tileWidth == self.tileHeight and
                         not (self.tileWidth & (self.tileWidth - 1)))
         self.sizeX = (((2 ** self.maxLevel) * self.tileWidth)
-                      if sizeX is None else int(sizeX))
+                      if sizeX is None else sizeX)
         self.sizeY = (((2 ** self.maxLevel) * self.tileHeight)
-                      if sizeY is None else int(sizeY))
-        self.encoding = encoding if encoding in ('PNG', 'JPEG') else 'PNG'
+                      if sizeY is None else sizeY)
+        if encoding not in ('PNG', 'JPEG'):
+            raise ValueError('Invalid encoding "%s"' % encoding)
+        self.encoding = encoding
         # Used for reporting tile information
         self.levels = self.maxLevel + 1
 

--- a/server/tilesource/test.py
+++ b/server/tilesource/test.py
@@ -30,7 +30,7 @@ except ImportError:
     logger.info('Error: Could not import PIL')
     # re-raise it for now, but maybe do something else in the future
     raise
-from six import StringIO
+from six import BytesIO
 
 from .base import TileSource, TileSourceException
 
@@ -138,7 +138,7 @@ class TestTileSource(TileSource):
             font=imageDrawFont
         )
 
-        output = StringIO()
+        output = BytesIO()
         image.save(output, self.encoding, quality=95)
         return output.getvalue()
 

--- a/server/tilesource/tiff.py
+++ b/server/tilesource/tiff.py
@@ -56,7 +56,8 @@ class TiffGirderTileSource(GirderTileSource):
         # Multiresolution TIFFs are stored with full-resolution layer in directory 0
         self._tiffDirectories.reverse()
 
-        self.tileSize = self._tiffDirectories[-1].tileSize
+        self.tileWidth = self._tiffDirectories[-1].tileWidth
+        self.tileHeight = self._tiffDirectories[-1].tileHeight
         self.levels = len(self._tiffDirectories)
         self.sizeX = self._tiffDirectories[-1].imageWidth
         self.sizeY = self._tiffDirectories[-1].imageHeight

--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -171,7 +171,7 @@ class TiledTiffDirectory(object):
 
     def _loadMetadata(self):
         self._tileWidth = self._tiffFile.GetField('TileWidth')
-        self._tileHight = self._tiffFile.GetField('TileLength')
+        self._tileHeight = self._tiffFile.GetField('TileLength')
         self._imageWidth = self._tiffFile.GetField('ImageWidth')
         self._imageHeight = self._tiffFile.GetField('ImageLength')
 
@@ -237,7 +237,7 @@ class TiledTiffDirectory(object):
 
         # TIFFCheckTile and TIFFComputeTile require pixel coordinates
         pixelX = x * self._tileWidth
-        pixelY = y * self._tileHight
+        pixelY = y * self._tileHeight
 
         if libtiff_ctypes.libtiff.TIFFCheckTile(
                 self._tiffFile, pixelX, pixelY, 0, 0) == 0:
@@ -381,7 +381,7 @@ class TiledTiffDirectory(object):
         :rtype: int
         """
         # TODO: fetch lazily and memoize
-        return self._tileHight
+        return self._tileHeight
 
 
     @property

--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -170,7 +170,8 @@ class TiledTiffDirectory(object):
 
 
     def _loadMetadata(self):
-        self._tileSize = self._tiffFile.GetField('TileWidth')
+        self._tileWidth = self._tiffFile.GetField('TileWidth')
+        self._tileHight = self._tiffFile.GetField('TileLength')
         self._imageWidth = self._tiffFile.GetField('ImageWidth')
         self._imageHeight = self._tiffFile.GetField('ImageLength')
 
@@ -235,8 +236,8 @@ class TiledTiffDirectory(object):
         # TODO: is it worth it to memoize this?
 
         # TIFFCheckTile and TIFFComputeTile require pixel coordinates
-        pixelX = x * self._tileSize
-        pixelY = y * self._tileSize
+        pixelX = x * self._tileWidth
+        pixelY = y * self._tileHight
 
         if libtiff_ctypes.libtiff.TIFFCheckTile(
                 self._tiffFile, pixelX, pixelY, 0, 0) == 0:
@@ -360,17 +361,6 @@ class TiledTiffDirectory(object):
 
 
     @property
-    def tileSize(self):
-        """
-        Get the pixel size of tiles.
-
-        :return: The tile size (length and height) in pixels.
-        :rtype: int
-        """
-        # TODO: fetch lazily and memoize
-        return self._tileSize
-
-    @property
     def tileWidth(self):
         """
         Get the pixel width of tiles.
@@ -379,7 +369,8 @@ class TiledTiffDirectory(object):
         :rtype: int
         """
         # TODO: fetch lazily and memoize
-        return self._tileSize
+        return self._tileWidth
+
 
     @property
     def tileHeight(self):
@@ -390,7 +381,8 @@ class TiledTiffDirectory(object):
         :rtype: int
         """
         # TODO: fetch lazily and memoize
-        return self._tileSize
+        return self._tileHight
+
 
     @property
     def imageWidth(self):

--- a/web_client/js/imageViewerWidget/geojs.js
+++ b/web_client/js/imageViewerWidget/geojs.js
@@ -20,7 +20,7 @@ girder.views.GeojsImageViewerWidget = girder.views.ImageViewerWidget.extend({
 
         // TODO: if a viewer already exists, do we render again?
         var w = this.sizeX, h = this.sizeY;
-        // TODO: this.levels and this.tileSize
+        // TODO: this.levels
         var mapParams = {
             node: this.el,
             ingcs: '+proj=longlat +axis=esu',
@@ -28,8 +28,8 @@ girder.views.GeojsImageViewerWidget = girder.views.ImageViewerWidget.extend({
             maxBounds: {left: 0, top: 0, right: w, bottom: h},
             center: {x: w / 2, y: h / 2},
             max: Math.ceil(Math.log(Math.max(
-                w / (this.tileWidth || this.tileSize),
-                h / (this.tileHeight || this.tileSize))) / Math.log(2)),
+                w / this.tileWidth,
+                h / this.tileHeight)) / Math.log(2)),
             clampBoundsX: true,
             clampBoundsY: true,
             zoom: 0
@@ -45,8 +45,8 @@ girder.views.GeojsImageViewerWidget = girder.views.ImageViewerWidget.extend({
                 return {x: 0, y: 0};
             },
             attribution: '',
-            tileWidth: this.tileWidth || this.tileSize,
-            tileHeight: this.tileHeight || this.tileSize,
+            tileWidth: this.tileWidth,
+            tileHeight: this.tileHeight,
             tileRounding: Math.ceil
         };
         this.viewer = geo.map(mapParams);


### PR DESCRIPTION
* Validate TestTileSource parameters in the REST API layer
 * Internal APIs should mostly assume that they are being called with
the correct types.
 * Necessary type conversion that's required due the limitations of HTTP
parameters is really an additional part of HTTP deserialization, and
should be performed by the REST API layer.
* Make TIFFTileSource use tileWidth and tileLength, instead of tileSize
 * This fixes a bug where the TileSource.getMetadata was returning "null"
for the tileWidth and tileHeight.
 * Since non-square tiles are now supported, this is simpler than trying to
also sometimes still use tileSize.
*  Use a BytesIO to store image data 