### PR TITLE
Add a bower postinstall step to install bower deps

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,11 +12,7 @@
     "url": "https://github.com/DigitalSlideArchive/large_image.git"
   },
   "dependencies": {
-    "bower": "^1.7.7",
-    "geojs": "0.8.0"
+    "angular": "^1.5.0"
   },
-  "devDependencies": {},
-  "scripts": {
-    "postinstall": "bower --quiet --allow-root install"
-  }
+  "devDependencies": {}
 }


### PR DESCRIPTION
@brianhelba I think this is what you wanted to do.  It adds `bower install` as a post install step just like `geojs` does.  The `bower_components` will be set up automagically after running `grunt init`.  I added `angular` as a dependency just to show off how it works; you can add whatever dependencies you need in the `bower.json` file.