### PR TITLE
Make the 'largeImage' field into a dict, holding all related values

### DIFF
--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -247,7 +247,7 @@ class LargeImageTilesTest(base.TestCase):
                     return False
                 self.assertIn('No large image file', exc.args[0])
             item = self.model('item').load(itemId, user=self.admin)
-            job = self.model('job', 'jobs').load(item['largeImageJobId'],
+            job = self.model('job', 'jobs').load(item['largeImage']['jobId'],
                                                  user=self.admin)
             if job['status'] == girder.plugins.jobs.constants.JobStatus.ERROR:
                 return None

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -37,14 +37,14 @@ def _postUpload(event):
     Item = ModelImporter.model('item')
     item = Item.load(fileObj['itemId'], force=True, exc=True)
 
-    if item.get('expectedLargeImage') and (
+    if item.get('largeImage', {}).get('expected') and (
             fileObj['name'].endswith('.tiff') or
             fileObj.get('mimeType') == 'image/tiff'):
         if fileObj.get('mimeType') != 'image/tiff':
             fileObj['mimeType'] = 'image/tiff'
             ModelImporter.model('file').save(fileObj)
-        del item['expectedLargeImage']
-        item['largeImage'] = fileObj['_id']
+        del item['largeImage']['expected']
+        item['largeImage']['fileId'] = fileObj['_id']
         Item.save(item)
 
 

--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -42,24 +42,23 @@ class ImageItem(Item):
         super(ImageItem, self).initialize()
 
     def createImageItem(self, item, fileObj, user=None, token=None):
-        if 'largeImage' in item:
+        # Using setdefault ensures that 'largeImage' is in the item
+        if 'fileId' in item.setdefault('largeImage', {}):
             # TODO: automatically delete the existing large file
             raise TileGeneralException('Item already has a largeImage set.')
         if fileObj['itemId'] != item['_id']:
             raise TileGeneralException('The provided file must be in the '
                                        'provided item.')
 
-        if item.get('expectedLargeImage'):
-            del item['expectedLargeImage']
-        if item.get('largeImageSourceName'):
-            del item['largeImageSourceName']
+        item['largeImage'].pop('expected', None)
+        item['largeImage'].pop('sourceName', None)
 
-        item['largeImage'] = fileObj['_id']
+        item['largeImage']['fileId'] = fileObj['_id']
         job = None
         for sourceName in self.AvailableSources:
             try:
                 self.AvailableSources[sourceName](item)
-                item['largeImageSourceName'] = sourceName
+                item['largeImage']['sourceName'] = sourceName
                 break
             except TileSourceAssetstoreException:
                 raise
@@ -67,11 +66,11 @@ class ImageItem(Item):
                 continue  # We want to try the next source
         else:
             # No source was successful
-            del item['largeImage']
+            del item['largeImage']['fileId']
             job = self._createLargeImageJob(item, fileObj, user, token)
-            item['expectedLargeImage'] = True
-            item['largeImageOriginalId'] = fileObj['_id']
-            item['largeImageJobId'] = job['_id']
+            item['largeImage']['expected'] = True
+            item['largeImage']['originalId'] = fileObj['_id']
+            item['largeImage']['jobId'] = job['_id']
 
         self.save(item)
         return job
@@ -166,8 +165,8 @@ class ImageItem(Item):
         if item == 'test':
             tileSource = TestTileSource(**kwargs)
         else:
-            sourceName = item.get('largeImageSourceName',
-                                  next(iter(cls.AvailableSources.items()))[0])
+            sourceName = item.get('largeImage', {}).get(
+                'sourceName', next(iter(cls.AvailableSources.items()))[0])
             tileSource = cls.AvailableSources[sourceName](item, **kwargs)
         return tileSource
 
@@ -184,17 +183,17 @@ class ImageItem(Item):
     def delete(self, item):
         Job = self.model('job', 'jobs')
         deleted = False
-        if 'largeImage' in item or 'largeImageJobId' in item:
+        if 'largeImage' in item:
             job = None
-            if 'largeImageJobId' in item:
+            if 'jobId' in item['largeImage']:
                 try:
-                    job = Job.load(item['largeImageJobId'], force=True,
+                    job = Job.load(item['largeImage']['jobId'], force=True,
                                    exc=True)
                 except ValidationException:
                     # The job has been deleted, but we still need to clean up
                     # the rest of the tile information
                     pass
-            if (item.get('expectedLargeImage') and job and
+            if (item['largeImage'].get('expected') and job and
                     job.get('status') in (
                     JobStatus.QUEUED, JobStatus.RUNNING)):
                 # cannot cleanly remove the large image, since a conversion
@@ -204,28 +203,27 @@ class ImageItem(Item):
                 return False
 
             # If this file was created by the worker job, delete it
-            if 'largeImageJobId' in item:
+            if 'jobId' in item['largeImage']:
                 if job:
                     # TODO: does this eliminate all traces of the job?
                     # TODO: do we want to remove the original job?
                     Job.remove(job)
-                del item['largeImageJobId']
+                del item['largeImage']['jobId']
 
-            if 'largeImageOriginalId' in item:
+            if 'originalId' in item['largeImage']:
                 # The large image file should not be the original file
-                assert item['largeImageOriginalId'] != item.get('largeImage')
+                assert item['largeImage']['originalId'] != \
+                    item['largeImage'].get('fileId')
 
-                if 'largeImage' in item:
+                if 'fileId' in item['largeImage']:
                     self.model('file').remove(self.model('file').load(
-                        id=item['largeImage'], force=True))
-                del item['largeImageOriginalId']
+                        id=item['largeImage']['fileId'], force=True))
+                del item['largeImage']['originalId']
 
-            if item.get('largeImageSourceName'):
-                del item['largeImageSourceName']
-            if 'largeImage' in item:
-                del item['largeImage']
+            item['largeImage'].pop('sourceName', None)
+            item['largeImage'].pop('fileId', None)
 
-            item['expectedLargeImage'] = True
+            item['largeImage']['expected'] = True
 
             self.save(item)
             deleted = True

--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -220,10 +220,7 @@ class ImageItem(Item):
                         id=item['largeImage']['fileId'], force=True))
                 del item['largeImage']['originalId']
 
-            item['largeImage'].pop('sourceName', None)
-            item['largeImage'].pop('fileId', None)
-
-            item['largeImage']['expected'] = True
+            del item['largeImage']
 
             self.save(item)
             deleted = True

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -138,7 +138,7 @@ class GirderTileSource(TileSource):
 
     def _getLargeImagePath(self):
         try:
-            largeImageFileId = self.item['largeImage']
+            largeImageFileId = self.item['largeImage']['fileId']
             # Access control checking should already have been done on item, so
             # don't repeat.
             # TODO: is it possible that the file is on a different item, so do

--- a/server/tilesource/svs.py
+++ b/server/tilesource/svs.py
@@ -46,8 +46,10 @@ class SVSGirderTileSource(GirderTileSource):
     @staticmethod
     def cacheKeyFunc(args, kwargs):
         item = args[0]
-        return (item.get('largeImage'), kwargs.get('jpegQuality'),
-                kwargs.get('jpegSubsampling'), kwargs.get('encoding'))
+        return (item.get('largeImage', {}).get('fileId'),
+                kwargs.get('jpegQuality'),
+                kwargs.get('jpegSubsampling'),
+                kwargs.get('encoding'))
 
     def __init__(self, item, jpegQuality=95, jpegSubsampling=0,
                  encoding='JPEG', **kwargs):

--- a/server/tilesource/tiff.py
+++ b/server/tilesource/tiff.py
@@ -38,7 +38,7 @@ class TiffGirderTileSource(GirderTileSource):
     @staticmethod
     def cacheKeyFunc(args, kwargs):
         item = args[0]
-        return item.get('largeImage')
+        return item.get('largeImage', {}).get('fileId')
 
     def __init__(self, item, **kwargs):
         super(TiffGirderTileSource, self).__init__(item, **kwargs)

--- a/web_client/js/imageViewerSelectWidget.js
+++ b/web_client/js/imageViewerSelectWidget.js
@@ -2,7 +2,8 @@ girder.wrap(girder.views.ItemView, 'render', function (render) {
     // ItemView is a special case in which rendering is done asynchronously,
     // so we must listen for a render event.
     this.once('g:rendered', function () {
-        if (this.model.get('largeImage')) {
+        if (this.model.get('largeImage') &&
+            this.model.get('largeImage').fileId) {
             this.imageViewerSelect = new girder.views.ImageViewerSelectWidget({
                 el: $('<div>', {class: 'g-item-image-viewer-select'})
                     .insertAfter(this.$('.g-item-info')),
@@ -25,7 +26,7 @@ girder.views.ImageViewerSelectWidget = girder.View.extend({
     },
 
     initialize: function (settings) {
-        this.itemId = settings.imageModel.get('largeImage') === 'test'
+        this.itemId = settings.imageModel.get('largeImage').fileId === 'test'
             ? 'test'
             : settings.imageModel.id;
         this.currentViewer = null;


### PR DESCRIPTION
* Make the 'largeImage' field into a dict, holding all related values
  * ``item['largeImage']`` now potentially contains the fields:
    * ``'fileId'``
    * ``'sourceName'``
    * ``'jobId'``
    * ``'expected'``
* Remove the entire 'largeImage' dict field when a large image is deleted