### PR TITLE
Only allow one job per item; make fileId optional.

### DIFF
--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -49,6 +49,10 @@ class ImageItem(Item):
         if fileObj['itemId'] != item['_id']:
             raise TileGeneralException('The provided file must be in the '
                                        'provided item.')
+        if (item['largeImage'].get('expected') is True and
+                'jobId' in item['largeImage']):
+            raise TileGeneralException('Item is scheduled to generate a '
+                                       'largeImage.')
 
         item['largeImage'].pop('expected', None)
         item['largeImage'].pop('sourceName', None)

--- a/server/rest.py
+++ b/server/rest.py
@@ -48,13 +48,19 @@ class TilesItemResource(Item):
         Description('Create a large image for this item.')
         .param('itemId', 'The ID of the item.', paramType='path')
         .param('fileId', 'The ID of the source file containing the image or '
-               '"test".')
+               '"test".  Required if more than one file in the item or using '
+               '"test"', required=False)
     )
     @access.user
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.WRITE)
     @filtermodel(model='job', plugin='jobs')
     def createTiles(self, item, params):
         largeImageFileId = params.get('fileId')
+        if largeImageFileId is None:
+            files = list(self.model('item').childFiles(
+                item=item, limit=2))
+            if len(files) == 1:
+                largeImageFileId = str(files[0]['_id'])
         if not largeImageFileId:
             raise RestException('Missing "fileId" parameter.')
 


### PR DESCRIPTION
If we have scheduled a conversion job, don't schedule another one.

Also, make fileId optional in POST image/{id}/tiles when there is exactly one file.
