### PR TITLE
Refactor how the "test" tile source is handled

### DIFF
--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -120,12 +120,6 @@ class LargeImageTilesTest(base.TestCase):
                       message.
         :returns: the tile information dictionary.
         """
-        resp = self.request(path='/item/%s/tiles' % itemId, method='DELETE',
-                            user=self.admin)
-        self.assertStatusOk(resp)
-        resp = self.request(path='/item/%s/tiles' % itemId, method='POST',
-                            user=self.admin, params={'fileId': 'test'})
-        self.assertStatusOk(resp)
         # We don't actually use the itemId to fetch test tiles
         try:
             resp = self.request(path='/item/test/tiles', user=self.admin,

--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -249,7 +249,7 @@ class LargeImageTilesTest(base.TestCase):
             except AssertionError as exc:
                 if 'File must have at least 1 level' in exc.args[0]:
                     return False
-                self.assertIn('No large image file', exc.args[0])
+                self.assertIn('is still pending creation', exc.args[0])
             item = self.model('item').load(itemId, user=self.admin)
             job = self.model('job', 'jobs').load(item['largeImage']['jobId'],
                                                  user=self.admin)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -45,6 +45,7 @@ def _postUpload(event):
             ModelImporter.model('file').save(fileObj)
         del item['largeImage']['expected']
         item['largeImage']['fileId'] = fileObj['_id']
+        item['largeImage']['sourceName'] = 'tiff'
         Item.save(item)
 
 

--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -166,11 +166,14 @@ class ImageItem(Item):
 
     @classmethod
     def _loadTileSource(cls, item, **kwargs):
-        if item == 'test':
+        if 'largeImage' not in item:
+            raise TileSourceException('No large image file in this item')
+
+        sourceName = item['largeImage']['sourceName']
+
+        if sourceName == 'test':
             tileSource = TestTileSource(**kwargs)
         else:
-            sourceName = item.get('largeImage', {}).get(
-                'sourceName', next(iter(cls.AvailableSources.items()))[0])
             tileSource = cls.AvailableSources[sourceName](item, **kwargs)
         return tileSource
 

--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -167,7 +167,10 @@ class ImageItem(Item):
     @classmethod
     def _loadTileSource(cls, item, **kwargs):
         if 'largeImage' not in item:
-            raise TileSourceException('No large image file in this item')
+            raise TileSourceException('No large image file in this item.')
+        if item['largeImage'].get('expected'):
+            raise TileSourceException('The large image file for this item is '
+                                      'still pending creation.')
 
         sourceName = item['largeImage']['sourceName']
 

--- a/server/rest.py
+++ b/server/rest.py
@@ -43,13 +43,16 @@ class TilesItemResource(Item):
                            self.getTilesThumbnail)
         apiRoot.item.route('GET', (':itemId', 'tiles', 'zxy', ':z', ':x', ':y'),
                            self.getTile)
+        apiRoot.item.route('GET', ('test', 'tiles'), self.getTestTilesInfo)
+        apiRoot.item.route('GET', ('test', 'tiles', 'zxy', ':z', ':x', ':y'),
+                           self.getTestTile)
 
     @describeRoute(
         Description('Create a large image for this item.')
         .param('itemId', 'The ID of the item.', paramType='path')
-        .param('fileId', 'The ID of the source file containing the image or '
-               '"test".  Required if more than one file in the item or using '
-               '"test"', required=False)
+        .param('fileId', 'The ID of the source file containing the image. '
+                         'Required if there is more than one file in the item.',
+               required=False)
     )
     @access.user
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.WRITE)
@@ -63,20 +66,16 @@ class TilesItemResource(Item):
                 largeImageFileId = str(files[0]['_id'])
         if not largeImageFileId:
             raise RestException('Missing "fileId" parameter.')
-
-        if largeImageFileId == 'test':
-            return None
-        else:
-            largeImageFile = self.model('file').load(
-                largeImageFileId, force=True, exc=True)
-            user = self.getCurrentUser()
-            token = self.getCurrentToken()
-            try:
-                return self.model(
-                    'image_item', 'large_image').createImageItem(
-                        item, largeImageFile, user, token)
-            except TileGeneralException as e:
-                raise RestException(e.message)
+        largeImageFile = self.model('file').load(
+            largeImageFileId, force=True, exc=True)
+        user = self.getCurrentUser()
+        token = self.getCurrentToken()
+        try:
+            return self.model(
+                'image_item', 'large_image').createImageItem(
+                    item, largeImageFile, user, token)
+        except TileGeneralException as e:
+            raise RestException(e.message)
 
     @classmethod
     def _parseTestParams(cls, params):
@@ -107,20 +106,28 @@ class TilesItemResource(Item):
 
     @describeRoute(
         Description('Get large image metadata.')
-        .param('itemId', 'The ID of the item or "test".', paramType='path')
+        .param('itemId', 'The ID of the item.', paramType='path')
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
     @access.public
-    def getTilesInfo(self, itemId, params):
-        if itemId == 'test':
-            item = 'test'
-            imageArgs = self._parseTestParams(params)
-        else:
-            item = self.model('item').load(
-                id=itemId, level=AccessType.READ,
-                user=self.getCurrentUser(), exc=True)
-            imageArgs = params
+    @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
+    def getTilesInfo(self, item, params):
+        # TODO: parse imageArgs?
+        imageArgs = params
+        try:
+            return self.model('image_item', 'large_image').getMetadata(
+                item, **imageArgs)
+        except TileGeneralException as e:
+            raise RestException(e.message, code=400)
+
+    @describeRoute(
+        Description('Get test large image metadata.')
+    )
+    @access.public
+    def getTestTilesInfo(self, params):
+        item = {'largeImage': {'sourceName': 'test'}}
+        imageArgs = self._parseTestParams(params)
         try:
             return self.model('image_item', 'large_image').getMetadata(
                 item, **imageArgs)
@@ -129,7 +136,7 @@ class TilesItemResource(Item):
 
     @describeRoute(
         Description('Get a large image tile.')
-        .param('itemId', 'The ID of the item or "test".', paramType='path')
+        .param('itemId', 'The ID of the item.', paramType='path')
         .param('z', 'The layer number of the tile (0 is the most zoomed-out '
                'layer).', paramType='path')
         .param('x', 'The X coordinate of the tile (0 is the left side).',
@@ -141,7 +148,9 @@ class TilesItemResource(Item):
     )
     @access.cookie
     @access.public
-    def getTile(self, itemId, z, x, y, params):
+    @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
+    def getTile(self, item, z, x, y, params):
+        # TODO: cache the user / item loading in the 'loadmodel' decorator
         try:
             x, y, z = int(x), int(y), int(z)
         except ValueError:
@@ -150,16 +159,39 @@ class TilesItemResource(Item):
             raise RestException('x, y, and z must be positive integers',
                                 code=400)
 
-        if itemId == 'test':
-            item = 'test'
-            imageArgs = self._parseTestParams(params)
-        else:
-            # TODO: cache the user / item loading too
-            item = self.model('item').load(
-                id=itemId, level=AccessType.READ,
-                user=self.getCurrentUser(), exc=True)
-            imageArgs = params
+        # TODO: parse imageArgs?
+        imageArgs = params
+        try:
+            tileData, tileMime = self.model(
+                'image_item', 'large_image').getTile(
+                    item, x, y, z, **imageArgs)
+        except TileGeneralException as e:
+            raise RestException(e.message, code=404)
+        cherrypy.response.headers['Content-Type'] = tileMime
+        return lambda: tileData
 
+    @describeRoute(
+        Description('Get a test large image tile.')
+        .param('z', 'The layer number of the tile (0 is the most zoomed-out '
+               'layer).', paramType='path')
+        .param('x', 'The X coordinate of the tile (0 is the left side).',
+               paramType='path')
+        .param('y', 'The Y coordinate of the tile (0 is the top).',
+               paramType='path')
+    )
+    @access.cookie
+    @access.public
+    def getTestTile(self, z, x, y, params):
+        try:
+            x, y, z = int(x), int(y), int(z)
+        except ValueError:
+            raise RestException('x, y, and z must be integers', code=400)
+        if x < 0 or y < 0 or z < 0:
+            raise RestException('x, y, and z must be positive integers',
+                                code=400)
+
+        item = {'largeImage': {'sourceName': 'test'}}
+        imageArgs = self._parseTestParams(params)
         try:
             tileData, tileMime = self.model(
                 'image_item', 'large_image').getTile(

--- a/server/rest.py
+++ b/server/rest.py
@@ -128,11 +128,7 @@ class TilesItemResource(Item):
     def getTestTilesInfo(self, params):
         item = {'largeImage': {'sourceName': 'test'}}
         imageArgs = self._parseTestParams(params)
-        try:
-            return self.model('image_item', 'large_image').getMetadata(
-                item, **imageArgs)
-        except TileGeneralException as e:
-            raise RestException(e.message, code=400)
+        return self.getTilesInfo.__wrapped__(self, item, imageArgs)
 
     @describeRoute(
         Description('Get a large image tile.')
@@ -182,24 +178,9 @@ class TilesItemResource(Item):
     @access.cookie
     @access.public
     def getTestTile(self, z, x, y, params):
-        try:
-            x, y, z = int(x), int(y), int(z)
-        except ValueError:
-            raise RestException('x, y, and z must be integers', code=400)
-        if x < 0 or y < 0 or z < 0:
-            raise RestException('x, y, and z must be positive integers',
-                                code=400)
-
         item = {'largeImage': {'sourceName': 'test'}}
         imageArgs = self._parseTestParams(params)
-        try:
-            tileData, tileMime = self.model(
-                'image_item', 'large_image').getTile(
-                    item, x, y, z, **imageArgs)
-        except TileGeneralException as e:
-            raise RestException(e.message, code=404)
-        cherrypy.response.headers['Content-Type'] = tileMime
-        return lambda: tileData
+        return self.getTile.__wrapped__(self, item, z, x, y, imageArgs)
 
     @describeRoute(
         Description('Remove a large image from this item.')

--- a/web_client/js/imageViewerSelectWidget.js
+++ b/web_client/js/imageViewerSelectWidget.js
@@ -26,9 +26,7 @@ girder.views.ImageViewerSelectWidget = girder.View.extend({
     },
 
     initialize: function (settings) {
-        this.itemId = settings.imageModel.get('largeImage').fileId === 'test'
-            ? 'test'
-            : settings.imageModel.id;
+        this.itemId = settings.imageModel.id;
         this.currentViewer = null;
         this.viewers = [
             {


### PR DESCRIPTION
This allows us to use the ``@loadmodel`` decorator in several places, and removes some special-case code.

It does remove the ability to permanently mark a specific item as a "test" largeImage. This functionality could be re-added if it turns out to be useful.