### PR TITLE
Region endpoint.

### DIFF
--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -250,3 +250,19 @@ class ImageItem(Item):
         thumbData, thumbMime = tileSource.getThumbnail(
             width, height, **kwargs)
         return thumbData, thumbMime
+
+    def getRegion(self, item, **kwargs):
+        """
+        Using a tile source, get an arbitrary region of the image, optionally
+        scaling the results.  Aspect ratio is preserved.
+
+        :param item: the item with the tile source.
+        :param **kwargs: optional arguments.  Some options are left, top,
+            right, bottom, regionWidth, regionHeight, units, width, height,
+            encoding, jpegQuality, and jpegSubsampling.  This is also passed to
+            the tile source.
+        :returns: regionData, regionMime: the image data and the mime type.
+        """
+        tileSource = self._loadTileSource(item, **kwargs)
+        thumbData, thumbMime = tileSource.getRegion(**kwargs)
+        return thumbData, thumbMime

--- a/server/rest.py
+++ b/server/rest.py
@@ -286,7 +286,7 @@ class TilesItemResource(Item):
         .param('regionHeight', 'The height of the region to return.',
                required=False, dataType='float')
         .param('units', 'Units used for left, top, right, bottom, '
-               'sourceWidth, and sourceHeight.  Note that output width and '
+               'regionWidth, and regionHeight.  Note that output width and '
                'height are always in pixels.', required=False,
                enum=['pixels', 'fraction'], default='pixels')
         .param('width', 'The maximum width of the output image in pixels.',

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -300,7 +300,9 @@ class TileSource(object):
         # still often inaccessible.
         image = PIL.Image.frombuffer(
             mode, (regionWidth, regionHeight),
-            '\x00' * (regionWidth * regionHeight * 4), 'raw', 'RGBA', 0, 1)
+            # PIL will reallocate buffers that aren't in 'raw', RGBA, 0, 1.
+            # See PIL documentation and code for more details.
+            b'\x00' * (regionWidth * regionHeight * 4), 'raw', 'RGBA', 0, 1)
         for x in range(xmin, xmax):
             for y in range(ymin, ymax):
                 tileData = self.getTile(

--- a/server/tilesource/dummy.py
+++ b/server/tilesource/dummy.py
@@ -30,5 +30,5 @@ class DummyTileSource(TileSource):
         self.sizeX = 0
         self.sizeY = 0
 
-    def getTile(self, x, y, z):
+    def getTile(self, x, y, z, **kwargs):
         return ''

--- a/server/tilesource/svs.py
+++ b/server/tilesource/svs.py
@@ -131,7 +131,7 @@ class SVSGirderTileSource(GirderTileSource):
                 'scale': scale
             })
 
-    def getTile(self, x, y, z, pilImageAllowed=False):
+    def getTile(self, x, y, z, pilImageAllowed=False, **kwargs):
         try:
             svslevel = self._svslevels[z]
         except IndexError:

--- a/server/tilesource/tiff.py
+++ b/server/tilesource/tiff.py
@@ -72,7 +72,7 @@ class TiffGirderTileSource(GirderTileSource):
         self.sizeX = self._tiffDirectories[-1].imageWidth
         self.sizeY = self._tiffDirectories[-1].imageHeight
 
-    def getTile(self, x, y, z):
+    def getTile(self, x, y, z, pilImageAllowed=False):
         try:
             return self._tiffDirectories[z].getTile(x, y)
         except IndexError:


### PR DESCRIPTION
Regions can optionally be scaled as part of the output.

This even works on sparse PTIF files at all resolutions.

There is currently no explicit guard on over-using memory.  We allocate memory for the PIL image in Python as a single block, which will gracefully fail if we ask for more memory than is in the system.  However, there are cases where python will fail to reuse memory after it has been used.  The memory is freed, but this still occurs.

We might want to use something like psutil to query how much memory the system has and not allow regions that use more than some factor of that (say 1/8th).  We could implement a lock so that a maximum of such a quantity of regions can be generated at a time, Otherwise, concurrent requests could OOM-kill the system.