### PR TITLE
 Settings and thumbnails list

### DIFF
--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -810,13 +810,19 @@ class LargeImageTilesTest(base.TestCase):
 
     def testSettings(self):
         from girder.plugins.large_image import constants
+        from girder.models.model_base import ValidationException
 
         for key in (constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS,
                     constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER):
             self.model('setting').set(key, 'false')
             self.assertFalse(self.model('setting').get(key))
-            self.model('setting').set(key, 'not a false value')
+            self.model('setting').set(key, 'true')
             self.assertTrue(self.model('setting').get(key))
+            try:
+                self.model('setting').set(key, 'not valid')
+                self.assertTrue(False)
+            except ValidationException as exc:
+                self.assertIn('Invalid setting', exc.args[0])
         self.model('setting').set(
             constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER, 'geojs')
         self.assertEqual(self.model('setting').get(

--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -807,3 +807,17 @@ class LargeImageTilesTest(base.TestCase):
         (width, height) = struct.unpack('!LL', image[16:24])
         self.assertEqual(width, 1000)
         self.assertEqual(height, 750)
+
+    def testSettings(self):
+        from girder.plugins.large_image import constants
+
+        for key in (constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS,
+                    constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER):
+            self.model('setting').set(key, 'false')
+            self.assertFalse(self.model('setting').get(key))
+            self.model('setting').set(key, 'not a false value')
+            self.assertTrue(self.model('setting').get(key))
+        self.model('setting').set(
+            constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER, 'geojs')
+        self.assertEqual(self.model('setting').get(
+            constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER), 'geojs')

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -55,6 +55,8 @@ def validateSettings(event):
 
     if key in (constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS,
                constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER):
+        if str(val).lower() not in ('false', 'true', ''):
+            return
         val = (str(val).lower() != 'false')
     elif key == constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER:
         val = str(val).strip()

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -22,6 +22,7 @@ from girder.constants import AccessType
 from girder.utility.model_importer import ModelImporter
 
 from .rest import TilesItemResource
+from . import constants
 
 
 def _postUpload(event):
@@ -49,6 +50,20 @@ def _postUpload(event):
         Item.save(item)
 
 
+def validateSettings(event):
+    key, val = event.info['key'], event.info['value']
+
+    if key in (constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS,
+               constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER):
+        val = (str(val).lower() != 'false')
+    elif key == constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER:
+        val = str(val).strip()
+    else:
+        return
+    event.info['value'] = val
+    event.preventDefault().stopPropagation()
+
+
 def load(info):
     TilesItemResource(info['apiRoot'])
 
@@ -56,3 +71,4 @@ def load(info):
         level=AccessType.READ, fields='largeImage')
 
     events.bind('data.process', 'large_image', _postUpload)
+    events.bind('model.setting.validate', 'large_image', validateSettings)

--- a/server/constants.py
+++ b/server/constants.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#############################################################################
+
+
+# Constants representing the setting keys for this plugin
+class PluginSettings:
+    LARGE_IMAGE_SHOW_THUMBNAILS = 'large_image.show_thumbnails'
+    LARGE_IMAGE_SHOW_VIEWER = 'large_image.show_viewer'
+    LARGE_IMAGE_DEFAULT_VIEWER = 'large_image.default_viewer'

--- a/web_client/js/configView.js
+++ b/web_client/js/configView.js
@@ -1,0 +1,149 @@
+/**
+ * Show the default quota settings for users and collections.
+ */
+girder.views.largeImageConfig = girder.View.extend({
+    events: {
+        'submit #g-large-image-form': function (event) {
+            event.preventDefault();
+            this.$('#g-large-image-error-message').empty();
+            this._saveSettings([{
+                key: 'large_image.show_thumbnails',
+                value: this.$('.g-large-image-thumbnails-show').prop('checked')
+            }, {
+                key: 'large_image.show_viewer',
+                value: this.$('.g-large-image-viewer-show').prop('checked')
+            }, {
+                key: 'large_image.default_viewer',
+                value: this.$('.g-large-image-default-viewer').val()
+            }]);
+        }
+    },
+    initialize: function () {
+        girder.views.largeImageConfig.getSettings(_.bind(
+            function (settings) {
+                this.settings = settings;
+                this.render();
+            }, this));
+    },
+
+    render: function () {
+        this.$el.html(girder.templates.largeImageConfig({
+            settings: this.settings,
+            viewers: girder.views.largeImageConfig.viewers
+        }));
+        if (!this.breadcrumb) {
+            this.breadcrumb = new girder.views.PluginConfigBreadcrumbWidget({
+                pluginName: 'Large image',
+                el: this.$('.g-config-breadcrumb-container'),
+                parentView: this
+            }).render();
+        }
+
+        return this;
+    },
+
+    _saveSettings: function (settings) {
+        /* Now save the settings */
+        girder.restRequest({
+            type: 'PUT',
+            path: 'system/setting',
+            data: {
+                list: JSON.stringify(settings)
+            },
+            error: null
+        }).done(_.bind(function () {
+            /* Clear the settings that may have been loaded. */
+            girder.views.largeImageConfig.clearSettings();
+            girder.events.trigger('g:alert', {
+                icon: 'ok',
+                text: 'Settings saved.',
+                type: 'success',
+                timeout: 4000
+            });
+        }, this)).error(_.bind(function (resp) {
+            this.$('#g-large-image-error-message').text(
+                resp.responseJSON.message
+            );
+        }, this));
+    }
+}, {
+    /* Class methods and objects */
+
+    /* The list of viewers is added as a property to the select widget view so
+     * that it is also available to the settings page. */
+    viewers: [
+        {
+            name: 'openseadragon',
+            label: 'OpenSeaDragon',
+            type: 'OpenseadragonImageViewerWidget'
+        },
+        {
+            name: 'openlayers',
+            label: 'OpenLayers',
+            type: 'OpenlayersImageViewerWidget'
+        },
+        {
+            name: 'leaflet',
+            label: 'Leaflet',
+            type: 'LeafletImageViewerWidget'
+        },
+        {
+            name: 'geojs',
+            label: 'GeoJS',
+            type: 'GeojsImageViewerWidget'
+        },
+        {
+            name: 'slideatlas',
+            label: 'SlideAtlas',
+            type: 'SlideAtlasImageViewerWidget'
+        }
+    ],
+
+    /**
+     * Get settings if we haven't yet done so.  Either way, call a callback
+     * when we have settings.
+     *
+     * @param {function} callback a function to call after the settings are
+     *      fetched.  If the settings are already present, this is called
+     *      without any delay.
+     */
+    getSettings: function (callback) {
+        if (!girder.views.largeImageConfig.settings) {
+            girder.restRequest({
+                type: 'GET',
+                path: 'system/setting',
+                data: {
+                    list: JSON.stringify([
+                        'large_image.show_thumbnails',
+                        'large_image.show_viewer',
+                        'large_image.default_viewer'
+                    ])
+                }
+            }).done(function (resp) {
+                girder.views.largeImageConfig.settings = resp;
+                if (callback) {
+                    callback(girder.views.largeImageConfig.settings);
+                }
+            });
+        } else {
+            if (callback) {
+                callback(girder.views.largeImageConfig.settings);
+            }
+        }
+    },
+
+    /**
+     * Clear the settings so that getSettings will refetch them.
+     */
+    clearSettings: function () {
+        delete girder.views.largeImageConfig.settings;
+    }
+});
+
+girder.router.route(
+    'plugins/large_image/config', 'largeImageConfig', function () {
+        girder.events.trigger('g:navigateTo',
+                              girder.views.largeImageConfig);
+    });
+
+girder.exposePluginConfig('large_image', 'plugins/large_image/config');

--- a/web_client/js/fileList.js
+++ b/web_client/js/fileList.js
@@ -1,0 +1,57 @@
+girder.wrap(girder.views.FileListWidget, 'render', function (render) {
+    render.call(this);
+    if (!this.parentItem || !this.parentItem.get('_id')) {
+        return this;
+    }
+    if (this.parentItem.getAccessLevel() < girder.AccessType.WRITE) {
+        return this;
+    }
+    var largeImage = this.parentItem.get('largeImage');
+    var files = this.collection.toArray();
+    _.each(files, function (file) {
+        var actions = $('.g-file-list-link[cid="' + file.cid + '"]',
+                        this.$el).closest('.g-file-list-entry').children(
+                        '.g-file-actions-container');
+        if (!actions.length) {
+            return;
+        }
+        var fileAction = girder.templates.largeImage_fileAction({
+            file: file, largeImage: largeImage});
+        if (fileAction) {
+            actions.prepend(fileAction);
+        }
+    });
+    $('.g-large-image-remove', this.$el).on('click', _.bind(function (e) {
+        girder.restRequest({
+            type: 'DELETE',
+            path: 'item/' + this.parentItem.id + '/tiles',
+            error: null
+        }).done(_.bind(function () {
+            this.parentItem.unset('largeImage');
+            this.parentItem.fetch();
+        }, this));
+    }, this));
+    $('.g-large-image-create', this.$el).on('click', _.bind(function (e) {
+        var cid = $(e.currentTarget).parent().attr('file-cid');
+        var fileId = this.collection.get(cid).id;
+        girder.restRequest({
+            type: 'POST',
+            path: 'item/' + this.parentItem.id + '/tiles',
+            data: {fileId: fileId},
+            error: function (error, status) {
+                if (error.status !== 0) {
+                    girder.events.trigger('g:alert', {
+                        text: error.responseJSON.message,
+                        type: 'info',
+                        timeout: 5000,
+                        icon: 'info'
+                    });
+                }
+            }
+        }).done(_.bind(function () {
+            this.parentItem.unset('largeImage');
+            this.parentItem.fetch();
+        }, this));
+    }, this));
+    return this;
+});

--- a/web_client/js/imageViewerSelectWidget.js
+++ b/web_client/js/imageViewerSelectWidget.js
@@ -64,7 +64,12 @@ girder.views.ImageViewerSelectWidget = girder.View.extend({
             viewers: this.viewers
         }));
         // TODO: choose an actual default, and update the option element to match
-        this._selectViewer(this.viewers[0].name);
+        var name = girder.views.ImageViewerSelectWidget.preferredViewer;
+        if (name === undefined) {
+            name = this.viewers[0].name;
+        }
+        $('select.form-control', this.$el).val(name);
+        this._selectViewer(name);
         return this;
     },
 
@@ -75,6 +80,7 @@ girder.views.ImageViewerSelectWidget = girder.View.extend({
         }
         this.$('.image-viewer').toggleClass('hidden', true);
 
+        girder.views.ImageViewerSelectWidget.preferredViewer = viewerName;
         var ViewerType = _.findWhere(this.viewers, {name: viewerName}).type;
         // GeoJs isn't always fully removing itself from its element when
         // destroyed, so use dedicated elements for each viewer for now

--- a/web_client/js/imageViewerSelectWidget.js
+++ b/web_client/js/imageViewerSelectWidget.js
@@ -28,45 +28,20 @@ girder.views.ImageViewerSelectWidget = girder.View.extend({
     initialize: function (settings) {
         this.itemId = settings.imageModel.id;
         this.currentViewer = null;
-        this.viewers = [
-            {
-                name: 'openseadragon',
-                label: 'OpenSeaDragon',
-                type: girder.views.OpenseadragonImageViewerWidget
-            },
-            {
-                name: 'openlayers',
-                label: 'OpenLayers',
-                type: girder.views.OpenlayersImageViewerWidget
-            },
-            {
-                name: 'leaflet',
-                label: 'Leaflet',
-                type: girder.views.LeafletImageViewerWidget
-            },
-            {
-                name: 'geojs',
-                label: 'GeoJS',
-                type: girder.views.GeojsImageViewerWidget
-            },
-            {
-                name: 'slideatlas',
-                label: 'SlideAtlas',
-                type: girder.views.SlideAtlasImageViewerWidget
-            }
-        ];
-
-        this.render();
+        girder.views.largeImageConfig.getSettings(
+            _.bind(this.render, this));
     },
 
     render: function () {
+        if (girder.views.largeImageConfig.settings['large_image.show_viewer'] === false) {
+            return this;
+        }
         this.$el.html(girder.templates.imageViewerSelectWidget({
-            viewers: this.viewers
+            viewers: girder.views.largeImageConfig.viewers
         }));
-        // TODO: choose an actual default, and update the option element to match
-        var name = girder.views.ImageViewerSelectWidget.preferredViewer;
-        if (name === undefined) {
-            name = this.viewers[0].name;
+        var name = girder.views.largeImageConfig.settings['large_image.default_viewer'];
+        if (_.findWhere(girder.views.largeImageConfig.viewers, {name: name}) === undefined) {
+            name = girder.views.largeImageConfig.viewers[0].name;
         }
         $('select.form-control', this.$el).val(name);
         this._selectViewer(name);
@@ -80,8 +55,9 @@ girder.views.ImageViewerSelectWidget = girder.View.extend({
         }
         this.$('.image-viewer').toggleClass('hidden', true);
 
-        girder.views.ImageViewerSelectWidget.preferredViewer = viewerName;
-        var ViewerType = _.findWhere(this.viewers, {name: viewerName}).type;
+        var viewer = _.findWhere(girder.views.largeImageConfig.viewers,
+                                 {name: viewerName});
+        var ViewerType = girder.views[viewer.type];
         // GeoJs isn't always fully removing itself from its element when
         // destroyed, so use dedicated elements for each viewer for now
         var viewerEl = this.$('#' + viewerName);
@@ -92,5 +68,4 @@ girder.views.ImageViewerSelectWidget = girder.View.extend({
             itemId: this.itemId
         });
     }
-
 });

--- a/web_client/js/imageViewerWidget/geojs.js
+++ b/web_client/js/imageViewerWidget/geojs.js
@@ -57,12 +57,12 @@ girder.views.GeojsImageViewerWidget = girder.views.ImageViewerWidget.extend({
 
     destroy: function () {
         if (this.viewer) {
-            // this.viewer.destroy();
+            this.viewer.exit();
             this.viewer = null;
         }
-        // if (window.geo) {
-        //     delete window.geo;
-        // }
+        if (window.geo) {
+            delete window.geo;
+        }
         girder.views.ImageViewerWidget.prototype.destroy.call(this);
     }
 });

--- a/web_client/js/itemList.js
+++ b/web_client/js/itemList.js
@@ -2,24 +2,29 @@
 
 girder.wrap(girder.views.ItemListWidget, 'render', function (render) {
     render.call(this);
-    var items = this.collection.toArray();
-    var parent = this.$el;
-    var hasAnyLargeImage = _.some(items, function (item) {
-        return item.attributes.largeImage;
-    });
-    if (hasAnyLargeImage) {
-        $.each(items, function (idx, item) {
-            var elem = $('<span class="large_image_thumbnail"/>');
-            if (item.attributes.largeImage) {
-                elem.append($('<img/>').attr(
-                        'src', girder.apiRoot + '/item/' + item.id +
-                        '/tiles/thumbnail?width=160&height=100'));
-                $('img', elem).one('error', function () {
-                    $('img', elem).addClass('failed-to-load');
-                });
-            }
-            $('a[g-item-cid="' + item.cid + '"]>i', parent).before(elem);
+    girder.views.largeImageConfig.getSettings(_.bind(function (settings) {
+        if (settings['large_image.show_thumbnails'] === false) {
+            return this;
+        }
+        var items = this.collection.toArray();
+        var parent = this.$el;
+        var hasAnyLargeImage = _.some(items, function (item) {
+            return item.attributes.largeImage;
         });
-    }
-    return this;
+        if (hasAnyLargeImage) {
+            $.each(items, function (idx, item) {
+                var elem = $('<div class="large_image_thumbnail"/>');
+                if (item.attributes.largeImage) {
+                    elem.append($('<img/>').attr(
+                            'src', girder.apiRoot + '/item/' + item.id +
+                            '/tiles/thumbnail?width=160&height=100'));
+                    $('img', elem).one('error', function () {
+                        $('img', elem).addClass('failed-to-load');
+                    });
+                }
+                $('a[g-item-cid="' + item.cid + '"]>i', parent).before(elem);
+            });
+        }
+        return this;
+    }, this));
 });

--- a/web_client/js/itemList.js
+++ b/web_client/js/itemList.js
@@ -1,7 +1,8 @@
 girder.wrap(girder.views.ItemListWidget, 'render', function (render) {
     render.call(this);
     girder.views.largeImageConfig.getSettings(_.bind(function (settings) {
-        if (settings['large_image.show_thumbnails'] === false) {
+        if (settings['large_image.show_thumbnails'] === false ||
+                $('.large_image_thumbnail', this.$el).length > 0) {
             return this;
         }
         var items = this.collection.toArray();

--- a/web_client/js/itemList.js
+++ b/web_client/js/itemList.js
@@ -1,5 +1,3 @@
-/* globals girder, _ */
-
 girder.wrap(girder.views.ItemListWidget, 'render', function (render) {
     render.call(this);
     girder.views.largeImageConfig.getSettings(_.bind(function (settings) {
@@ -9,12 +7,12 @@ girder.wrap(girder.views.ItemListWidget, 'render', function (render) {
         var items = this.collection.toArray();
         var parent = this.$el;
         var hasAnyLargeImage = _.some(items, function (item) {
-            return item.attributes.largeImage;
+            return item.has('largeImage');
         });
         if (hasAnyLargeImage) {
             $.each(items, function (idx, item) {
                 var elem = $('<div class="large_image_thumbnail"/>');
-                if (item.attributes.largeImage) {
+                if (item.get('largeImage')) {
                     elem.append($('<img/>').attr(
                             'src', girder.apiRoot + '/item/' + item.id +
                             '/tiles/thumbnail?width=160&height=100'));

--- a/web_client/js/itemList.js
+++ b/web_client/js/itemList.js
@@ -1,0 +1,25 @@
+/* globals girder, _ */
+
+girder.wrap(girder.views.ItemListWidget, 'render', function (render) {
+    render.call(this);
+    var items = this.collection.toArray();
+    var parent = this.$el;
+    var hasAnyLargeImage = _.some(items, function (item) {
+        return item.attributes.largeImage;
+    });
+    if (hasAnyLargeImage) {
+        $.each(items, function (idx, item) {
+            var elem = $('<span class="large_image_thumbnail"/>');
+            if (item.attributes.largeImage) {
+                elem.append($('<img/>').attr(
+                        'src', girder.apiRoot + '/item/' + item.id +
+                        '/tiles/thumbnail?width=160&height=100'));
+                $('img', elem).one('error', function () {
+                    $('img', elem).addClass('failed-to-load');
+                });
+            }
+            $('a[g-item-cid="' + item.cid + '"]>i', parent).before(elem);
+        });
+    }
+    return this;
+});

--- a/web_client/stylesheets/fileList.styl
+++ b/web_client/stylesheets/fileList.styl
@@ -1,0 +1,15 @@
+span.fa-stack
+  position relative
+  i
+    position absolute
+    left 0
+    top 0
+  i:first-child
+    position relative
+  i.fa-cancel-cover
+    font-size 75%
+    left 40%
+    top -30%
+    color red
+.g-large-image-expected
+  opacity 0.5

--- a/web_client/stylesheets/imageViewerSelectWidget.styl
+++ b/web_client/stylesheets/imageViewerSelectWidget.styl
@@ -6,5 +6,5 @@
 
   .image-viewer
     border 1px solid #f0f0f0
-    width 800px
+    width 100%
     height 600px

--- a/web_client/stylesheets/itemList.styl
+++ b/web_client/stylesheets/itemList.styl
@@ -1,4 +1,4 @@
-span.large_image_thumbnail
+div.large_image_thumbnail
   display inline-block
   width 160px
   img

--- a/web_client/stylesheets/itemList.styl
+++ b/web_client/stylesheets/itemList.styl
@@ -1,0 +1,8 @@
+span.large_image_thumbnail
+  display inline-block
+  width 160px
+  img
+    display block
+    margin auto
+    &.failed-to-load
+      display none

--- a/web_client/templates/largeImageConfig.jade
+++ b/web_client/templates/largeImageConfig.jade
@@ -1,0 +1,31 @@
+.g-config-breadcrumb-container
+p.g-large-image-description
+  | Very large images can be served as tiles, allowing many different viewers
+  | to show them.
+form#g-large-image-form(role="form")
+  .form-group
+    label Large image thumbnails in item lists
+      .g-large-image-thumbnails-container
+        label.radio-inline
+          input.g-large-image-thumbnails-show(type="radio" name="g-large-image-thumbnails" checked=(settings['large_image.show_thumbnails'] !== false ? 'checked': undefined))
+          | Show thumbnails
+        label.radio-inline
+          input.g-large-image-thumbnails-hide(type="radio" name="g-large-image-thumbnails" checked=(settings['large_image.show_thumbnails'] !== false ? undefined : 'checked'))
+          | Don't show
+  .form-group
+    label Large images in items
+      .g-large-image-viewer-container
+        label.radio-inline
+          input.g-large-image-viewer-show(type="radio" name="g-large-image-viewer" checked=(settings['large_image.show_viewer'] !== false ? 'checked': undefined))
+          | Show viewer
+        label.radio-inline
+          input.g-large-image-viewer-hide(type="radio" name="g-large-image-viewer" checked=(settings['large_image.show_viewer'] !== false ? undefined : 'checked'))
+          | Don't show
+  .form-group
+    label Default large image item viewer 
+      .g-large-image-default-viewer-container
+        select.form-control.input-sm.g-large-image-default-viewer
+          each viewer in viewers
+            option(value=viewer.name, selected=(settings['large_image.default_viewer'] === viewer.name)) #{viewer.label}
+  p#g-large-image-error-message.g-validation-failed-message
+  input.btn.btn-sm.btn-primary(type="submit", value="Save")

--- a/web_client/templates/largeImage_fileAction.jade
+++ b/web_client/templates/largeImage_fileAction.jade
@@ -1,0 +1,11 @@
+if largeImage && file.id === largeImage.fileId && largeImage.expected !== true
+  a.g-large-image-remove(title="Remove large image")
+    span.fa-stack
+      i.icon-picture
+      i.icon-cancel.fa-cancel-cover
+else if largeImage && largeImage.expected === true
+  a.g-large-image-expected(title="A large image file is being generated")
+    i.icon-picture
+else if !largeImage || !largeImage.fileId
+  a.g-large-image-create(title="Use this file for a large image")
+    i.icon-picture


### PR DESCRIPTION
This currently has the region endpoints PR in the commit history; it can be separated from that, though it would be easier if that PR is resolved first instead.

This add a plugin settings page that allows turning on and off the image viewer on item pages, thumbnails in item lists, and setting the default viewer.  It adds thumbnails on item lists.  It adds additional actions on file lists: if a large image file is set, it can be removed.  If not set, it can be added to any file in the item.  If expected, the large image action icon is shown with some transparency to indicate that it is in progress.

There aren't any client tests yet.

Resolves issues #39 (client settings), #40 (thumbnails), and #41 (button to mark large image).