### PR TITLE
Allow public access of large image settings.

### DIFF
--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -827,3 +827,14 @@ class LargeImageTilesTest(base.TestCase):
             constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER, 'geojs')
         self.assertEqual(self.model('setting').get(
             constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER), 'geojs')
+        # Test the system/setting/large_image end point
+        resp = self.request(path='/system/setting/large_image', user=None)
+        self.assertStatusOk(resp)
+        settings = resp.json
+        # The values were set earlier
+        self.assertEqual(settings[
+            constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER], 'geojs')
+        self.assertEqual(settings[
+            constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER], True)
+        self.assertEqual(settings[
+            constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS], True)

--- a/server/rest.py
+++ b/server/rest.py
@@ -27,6 +27,8 @@ from girder.models.model_base import AccessType
 
 from .models import TileGeneralException
 
+from . import constants
+
 
 class TilesItemResource(Item):
 
@@ -48,6 +50,9 @@ class TilesItemResource(Item):
         apiRoot.item.route('GET', ('test', 'tiles'), self.getTestTilesInfo)
         apiRoot.item.route('GET', ('test', 'tiles', 'zxy', ':z', ':x', ':y'),
                            self.getTestTile)
+        # This is added to the system route
+        apiRoot.system.route('GET', ('setting', 'large_image'),
+                             self.getPublicSettings)
 
     @describeRoute(
         Description('Create a large image for this item.')
@@ -332,3 +337,15 @@ class TilesItemResource(Item):
             raise RestException('Value Error: %s' % e.message)
         cherrypy.response.headers['Content-Type'] = regionMime
         return lambda: regionData
+
+    @describeRoute(
+        Description('Get public settings for large image display.')
+    )
+    @access.public
+    def getPublicSettings(self, params):
+        keys = [
+            constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS,
+            constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER,
+            constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER,
+        ]
+        return {k: self.model('setting').get(k) for k in keys}

--- a/web_client/js/configView.js
+++ b/web_client/js/configView.js
@@ -111,14 +111,7 @@ girder.views.largeImageConfig = girder.View.extend({
         if (!girder.views.largeImageConfig.settings) {
             girder.restRequest({
                 type: 'GET',
-                path: 'system/setting',
-                data: {
-                    list: JSON.stringify([
-                        'large_image.show_thumbnails',
-                        'large_image.show_viewer',
-                        'large_image.default_viewer'
-                    ])
-                }
+                path: 'system/setting/large_image'
             }).done(function (resp) {
                 girder.views.largeImageConfig.settings = resp;
                 if (callback) {


### PR DESCRIPTION
Otherwise, unless you are logged in as an admin, the client can't read them.

I think Girder ultimately needs access control on individual settings, but that is a bigger issue.