### PR TITLE
Better handling of exceptions when loading tile soruces

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -36,6 +36,7 @@ add_python_test(tiles PLUGIN large_image BIND_SERVER EXTERNAL_DATA
   "sample_image.ptif" "plugins/large_image/sample_image.ptif"
   "sample_svs_image.svs" "plugins/large_image/sample_svs_image.TCGA-DU-6399-01A-01-TS1.e8eb65de-d63e-42db-af6f-14fefbbdf7bd.svs"
   )
+add_python_test(import PLUGIN large_image)
 set_property(TEST server_large_image.tiles APPEND PROPERTY ENVIRONMENT
   "LARGE_IMAGE_DATA=${PROJECT_BINARY_DIR}/data/plugins/large_image")
 add_web_client_test(example "${CMAKE_CURRENT_LIST_DIR}/plugin_tests/exampleSpec.js" PLUGIN large_image)

--- a/plugin_tests/import_test.py
+++ b/plugin_tests/import_test.py
@@ -60,4 +60,5 @@ class LargeImageTilesTest(base.TestCase):
             self.assertTrue(False)
         except ImportError as exc:
             self.assertIn('No module named openslide', exc.args[0])
+        sys.modules['girder.plugins.large_image.tilesource.test'] = None
         reload_module(girder.plugins.large_image.tilesource)

--- a/plugin_tests/import_test.py
+++ b/plugin_tests/import_test.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+##############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+##############################################################################
+
+import os
+import sys
+from six.moves import reload_module
+
+import girder
+from girder import config
+from tests import base
+
+
+# boiler plate to start and stop the server
+
+os.environ['GIRDER_PORT'] = os.environ.get('GIRDER_TEST_PORT', '20200')
+config.loadConfig()  # Must reload config to pickup correct port
+
+
+def setUpModule():
+    base.enabledPlugins.append('large_image')
+    base.startServer(False)
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class LargeImageTilesTest(base.TestCase):
+    def testImportErrors(self):
+        for key in ['openslide', 'PIL', 'libtiff']:
+            sys.modules[key] = None
+        try:
+            reload_module(girder.plugins.large_image.tilesource.test)
+            self.assertTrue(False)
+        except ImportError as exc:
+            self.assertIn('No module named PIL', exc.args[0])
+        try:
+            reload_module(girder.plugins.large_image.tilesource.tiff_reader)
+            self.assertTrue(False)
+        except ImportError as exc:
+            self.assertIn('No module named libtiff', exc.args[0])
+        try:
+            reload_module(girder.plugins.large_image.tilesource.svs)
+            self.assertTrue(False)
+        except ImportError as exc:
+            self.assertIn('No module named openslide', exc.args[0])
+        reload_module(girder.plugins.large_image.tilesource)

--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -538,8 +538,14 @@ class LargeImageTilesTest(base.TestCase):
         # We can't actually load the dummy source via the endpoints if we have
         # all of the requirements installed, so just check that it exists and
         # will return appropriate values.
-        import girder.plugins.large_image.tilesource.dummy
-        dummy = girder.plugins.large_image.tilesource.dummy.DummyTileSource()
+        from girder.plugins.large_image.tilesource.dummy import DummyTileSource
+        from girder.plugins.large_image.tilesource import TileSourceException
+        try:
+            dummy = DummyTileSource()
+            self.assertTrue(False)
+        except TileSourceException as exc:
+            self.assertIn('not a real tile source', exc.args[0])
+        dummy = DummyTileSource(allowDummy=True)
         self.assertEqual(dummy.getTile(0, 0, 0), '')
         tileMetadata = dummy.getMetadata()
         self.assertEqual(tileMetadata['tileWidth'], 0)

--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -539,13 +539,7 @@ class LargeImageTilesTest(base.TestCase):
         # all of the requirements installed, so just check that it exists and
         # will return appropriate values.
         from girder.plugins.large_image.tilesource.dummy import DummyTileSource
-        from girder.plugins.large_image.tilesource import TileSourceException
-        try:
-            dummy = DummyTileSource()
-            self.assertTrue(False)
-        except TileSourceException as exc:
-            self.assertIn('not a real tile source', exc.args[0])
-        dummy = DummyTileSource(allowDummy=True)
+        dummy = DummyTileSource()
         self.assertEqual(dummy.getTile(0, 0, 0), '')
         tileMetadata = dummy.getMetadata()
         self.assertEqual(tileMetadata['tileWidth'], 0)

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -51,6 +51,7 @@ class TileSource(object):
         'JPEG': 'image/jpeg',
         'PNG': 'image/png'
     }
+    name = None
 
     def __init__(self):
         self.tileWidth = None
@@ -158,6 +159,16 @@ class TileSource(object):
         bottom = min(metadata['sizeY'], max(top, int(round(bottom))))
 
         return left, top, right, bottom
+
+    @classmethod
+    def canRead(cls, *args, **kwargs):
+        """
+        Check if we can read the input.  This takes the same parameters as
+        __init__.
+
+        :returns: True if this class can read the input.  False if it cannot.
+        """
+        return False
 
     def getMetadata(self):
         return {
@@ -360,3 +371,17 @@ class GirderTileSource(TileSource):
         except (KeyError, ValidationException, TileSourceException) as e:
             raise TileSourceException(
                 'No large image file in this item: %s' % e.message)
+
+    @classmethod
+    def canRead(cls, item, *args, **kwargs):
+        """
+        Check if we can read the input.  This takes the same parameters as
+        __init__.
+
+        :returns: True if this class can read the input.  False if it cannot.
+        """
+        try:
+            cls(item, *args, **kwargs)
+            return True
+        except TileSourceException:
+            return False

--- a/server/tilesource/dummy.py
+++ b/server/tilesource/dummy.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-###############################################################################
+##############################################################################
 #  Copyright Kitware Inc.
 #
 #  Licensed under the Apache License, Version 2.0 ( the "License" );
@@ -15,12 +15,13 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-###############################################################################
+##############################################################################
 
-from .base import TileSource, TileSourceException
+from .base import TileSource
 
 
 class DummyTileSource(TileSource):
+    name = 'dummy'
 
     def __init__(self, *args, **kwargs):
         super(DummyTileSource, self).__init__()
@@ -29,9 +30,6 @@ class DummyTileSource(TileSource):
         self.levels = 0
         self.sizeX = 0
         self.sizeY = 0
-        if not kwargs.get('allowDummy'):
-            raise TileSourceException(
-                'DummyTileSource is not a real tile source')
 
     def getTile(self, x, y, z, **kwargs):
         return ''

--- a/server/tilesource/dummy.py
+++ b/server/tilesource/dummy.py
@@ -17,7 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
-from .base import TileSource
+from .base import TileSource, TileSourceException
 
 
 class DummyTileSource(TileSource):
@@ -29,6 +29,9 @@ class DummyTileSource(TileSource):
         self.levels = 0
         self.sizeX = 0
         self.sizeY = 0
+        if not kwargs.get('allowDummy'):
+            raise TileSourceException(
+                'DummyTileSource is not a real tile source')
 
     def getTile(self, x, y, z, **kwargs):
         return ''

--- a/server/tilesource/svs.py
+++ b/server/tilesource/svs.py
@@ -19,7 +19,6 @@
 
 import math
 import six
-import PIL
 
 from girder import logger
 from six import BytesIO
@@ -27,8 +26,11 @@ from six.moves import range
 
 try:
     import openslide
+    import PIL
 except ImportError:
-    logger.warning('Could not import openslide')
+    from girder.constants import TerminalColor
+    print(TerminalColor.error('Error: Could not import openslide'))
+    logger.exception('Error: Could not import openslide')
     raise
 
 from .base import GirderTileSource, TileSourceException

--- a/server/tilesource/svs.py
+++ b/server/tilesource/svs.py
@@ -20,18 +20,11 @@
 import math
 import six
 
-from girder import logger
 from six import BytesIO
 from six.moves import range
 
-try:
-    import openslide
-    import PIL
-except ImportError:
-    from girder.constants import TerminalColor
-    print(TerminalColor.error('Error: Could not import openslide'))
-    logger.exception('Error: Could not import openslide')
-    raise
+import openslide
+import PIL
 
 from .base import GirderTileSource, TileSourceException
 from .cache import LruCacheMetaclass
@@ -44,6 +37,7 @@ class SVSGirderTileSource(GirderTileSource):
     """
     cacheMaxSize = 2
     cacheTimeout = 60
+    name = 'svs'
 
     @staticmethod
     def cacheKeyFunc(args, kwargs):

--- a/server/tilesource/test.py
+++ b/server/tilesource/test.py
@@ -18,24 +18,18 @@
 ###############################################################################
 
 import colorsys
-
-from girder import logger
-
-try:
-    import PIL
-    from PIL import Image, ImageDraw, ImageFont
-    if int(PIL.PILLOW_VERSION.split('.')[0]) < 3:
-        raise ImportError('Pillow v3.0 or later is required')
-except ImportError:
-    logger.info('Error: Could not import PIL')
-    # re-raise it for now, but maybe do something else in the future
-    raise
 from six import BytesIO
-
 from .base import TileSource, TileSourceException
+
+import PIL
+from PIL import Image, ImageDraw, ImageFont
+if int(PIL.PILLOW_VERSION.split('.')[0]) < 3:
+    raise ImportError('Pillow v3.0 or later is required')
 
 
 class TestTileSource(TileSource):
+    name = 'test'
+
     def __init__(self, minLevel=0, maxLevel=9,
                  tileWidth=256, tileHeight=256, sizeX=None, sizeY=None,
                  fractal=False, encoding='PNG'):

--- a/server/tilesource/tiff.py
+++ b/server/tilesource/tiff.py
@@ -40,6 +40,7 @@ class TiffGirderTileSource(GirderTileSource):
     """
     cacheMaxSize = 2
     cacheTimeout = 60
+    name = 'tiff'
 
     @staticmethod
     def cacheKeyFunc(args, kwargs):

--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -22,15 +22,7 @@ import ctypes
 import os
 import six
 
-
-try:
-    from libtiff import libtiff_ctypes
-except ImportError:
-    import girder
-    from girder.constants import TerminalColor
-    print(TerminalColor.error('Error: Could not import libtiff'))
-    girder.logger.exception('Error: Could not import libtiff')
-    raise
+from libtiff import libtiff_ctypes
 
 from .cache import instanceLruCache
 

--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -20,14 +20,16 @@
 import base64
 import ctypes
 import os
-
 import six
+
+
 try:
     from libtiff import libtiff_ctypes
 except ImportError:
-    # TODO: change print to use logger
-    print 'Error: Could not import libtiff'
-    # re-raise it for now, but maybe do something else in the future
+    import girder
+    from girder.constants import TerminalColor
+    print(TerminalColor.error('Error: Could not import libtiff'))
+    girder.logger.exception('Error: Could not import libtiff')
     raise
 
 from .cache import instanceLruCache


### PR DESCRIPTION
When we installed the large_image plugin in an environment that had openslide-python but not the libtiff module, the DummyTileSource replaced the tiff tile source (as intended), but then this "processed" SVS files and prevented them from working.  This change will allow the file to be properly handed off to the SVS tile source.

Improve the error messages for import failures.

Added some tests for import failures.