### PR TITLE
Refactor the tile sources so that they can be used without Girder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ node_modules
 _build
 .*.swp
 .*.swo
+env
+dist
+build
+large_image.egg-info

--- a/large_image.py
+++ b/large_image.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+##############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+##############################################################################
+
+from server import tilesource
+getTileSource = tilesource.getTileSource  # noqa

--- a/large_image/__init__.py
+++ b/large_image/__init__.py
@@ -17,5 +17,8 @@
 #  limitations under the License.
 ##############################################################################
 
+import server
 from server import tilesource
 getTileSource = tilesource.getTileSource  # noqa
+
+__all__ = [server, tilesource, getTileSource]

--- a/plugin.cmake
+++ b/plugin.cmake
@@ -36,7 +36,16 @@ add_python_test(tiles PLUGIN large_image BIND_SERVER EXTERNAL_DATA
   "sample_image.ptif" "plugins/large_image/sample_image.ptif"
   "sample_svs_image.svs" "plugins/large_image/sample_svs_image.TCGA-DU-6399-01A-01-TS1.e8eb65de-d63e-42db-af6f-14fefbbdf7bd.svs"
   )
-add_python_test(import PLUGIN large_image)
 set_property(TEST server_large_image.tiles APPEND PROPERTY ENVIRONMENT
   "LARGE_IMAGE_DATA=${PROJECT_BINARY_DIR}/data/plugins/large_image")
+
+add_python_test(import PLUGIN large_image)
+
+add_python_test(girderless PLUGIN large_image BIND_SERVER EXTERNAL_DATA
+  "sample_image.ptif" "plugins/large_image/sample_image.ptif"
+  "sample_svs_image.svs" "plugins/large_image/sample_svs_image.TCGA-DU-6399-01A-01-TS1.e8eb65de-d63e-42db-af6f-14fefbbdf7bd.svs"
+  )
+set_property(TEST server_large_image.girderless APPEND PROPERTY ENVIRONMENT
+  "LARGE_IMAGE_DATA=${PROJECT_BINARY_DIR}/data/plugins/large_image")
+
 add_web_client_test(example "${CMAKE_CURRENT_LIST_DIR}/plugin_tests/exampleSpec.js" PLUGIN large_image)

--- a/plugin_tests/girderless_test.py
+++ b/plugin_tests/girderless_test.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+##############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+##############################################################################
+
+import math
+import os
+
+from tests import base
+
+JPEGHeader = '\xff\xd8\xff'
+PNGHeader = '\x89PNG'
+
+
+class LargeImageGirderlessTest(base.TestCase):
+    def _testTilesZXY(self, source, metadata, tileParams={},
+                      imgHeader=JPEGHeader):
+        """
+        Test that the tile source returns images.
+
+        :param source: the tile source class to get tiles from.
+        :param metadata: tile information used to determine the expected
+                         valid tiles.  If 'sparse' is added to it, tiles
+                         are allowed to not exist above that level.
+        :param tileParams: optional parameters to send to getTile.
+        :param imgHeader: if something other than a JPEG is expected, this is
+                          the first few bytes of the expected image.
+        """
+        from server import tilesource
+        # We should get images for all valid levels, but only within the
+        # expected range of tiles.
+        for z in range(metadata.get('minLevel', 0), metadata['levels']):
+            maxX = int(math.ceil(float(metadata['sizeX']) * 2 ** (
+                z - metadata['levels'] + 1) / metadata['tileWidth']) - 1)
+            maxY = int(math.ceil(float(metadata['sizeY']) * 2 ** (
+                z - metadata['levels'] + 1) / metadata['tileHeight']) - 1)
+            # Check the four corners on each level
+            for (x, y) in ((0, 0), (maxX, 0), (0, maxY), (maxX, maxY)):
+                try:
+                    image = source.getTile(x, y, z, **tileParams)
+                except tilesource.TileSourceException:
+                    image = None
+                if (image is None and
+                        metadata.get('sparse') and z > metadata['sparse']):
+                    continue
+                self.assertIsNotNone(image)
+                self.assertEqual(image[:len(imgHeader)], imgHeader)
+            # Check out of range each level
+            for (x, y) in ((-1, 0), (maxX + 1, 0), (0, -1), (0, maxY + 1)):
+                try:
+                    image = source.getTile(x, y, z, **tileParams)
+                except tilesource.TileSourceException:
+                    image = None
+                self.assertIsNone(image)
+        # Check negative z level
+        try:
+            image = source.getTile(0, 0, -1, **tileParams)
+        except tilesource.TileSourceException:
+            image = None
+        self.assertIsNone(image)
+        # If we set the minLevel, test one lower than it
+        if 'minLevel' in metadata:
+            image = source.getTile(0, 0, metadata['minLevel'] - 1,
+                                   **tileParams)
+            self.assertIsNone(image)
+        # Check too large z level
+        try:
+            image = source.getTile(0, 0, metadata['levels'], **tileParams)
+        except tilesource.TileSourceException:
+            image = None
+        self.assertIsNone(image)
+
+    def setUp(*args, **kwargs):
+        # Avoid starting girder
+        pass
+
+    def testWithoutGirder(self):
+        from server import tilesource
+        # Make sure we are running in a girderless environment
+        self.assertIsNone(tilesource.girder)
+
+    def testTilesFromPTIF(self):
+        from server import tilesource
+
+        canread = tilesource.AvailableTileSources['tifffile'].canRead(
+            os.path.join(os.path.dirname(__file__), 'test_files',
+                         'yb10kx5k.png'))
+        self.assertFalse(canread)
+        canread = tilesource.AvailableTileSources['tifffile'].canRead(
+            os.path.join(os.environ['LARGE_IMAGE_DATA'],
+                         'sample_image.ptif'))
+        self.assertTrue(canread)
+        source = tilesource.AvailableTileSources['tifffile'](
+            os.path.join(os.environ['LARGE_IMAGE_DATA'],
+                         'sample_image.ptif'))
+        tileMetadata = source.getMetadata()
+        self.assertEqual(tileMetadata['tileWidth'], 256)
+        self.assertEqual(tileMetadata['tileHeight'], 256)
+        self.assertEqual(tileMetadata['sizeX'], 58368)
+        self.assertEqual(tileMetadata['sizeY'], 12288)
+        self.assertEqual(tileMetadata['levels'], 9)
+        tileMetadata['sparse'] = 5
+        self._testTilesZXY(source, tileMetadata)
+
+    def testTilesFromSVS(self):
+        from server import tilesource
+
+        canread = tilesource.AvailableTileSources['svsfile'].canRead(
+            os.path.join(os.path.dirname(__file__), 'test_files',
+                         'yb10kx5k.png'))
+        self.assertFalse(canread)
+        canread = tilesource.AvailableTileSources['svsfile'].canRead(
+            os.path.join(
+                os.environ['LARGE_IMAGE_DATA'],
+                'sample_svs_image.TCGA-DU-6399-'
+                '01A-01-TS1.e8eb65de-d63e-42db-af6f-14fefbbdf7bd.svs'))
+        self.assertTrue(canread)
+        source = tilesource.AvailableTileSources['svsfile'](os.path.join(
+            os.environ['LARGE_IMAGE_DATA'], 'sample_svs_image.TCGA-DU-6399-'
+            '01A-01-TS1.e8eb65de-d63e-42db-af6f-14fefbbdf7bd.svs'))
+        tileMetadata = source.getMetadata()
+        self.assertEqual(tileMetadata['tileWidth'], 240)
+        self.assertEqual(tileMetadata['tileHeight'], 240)
+        self.assertEqual(tileMetadata['sizeX'], 31872)
+        self.assertEqual(tileMetadata['sizeY'], 13835)
+        self.assertEqual(tileMetadata['levels'], 9)
+        self._testTilesZXY(source, tileMetadata)
+        # We can get to the tilesource class directly, too.
+        params = {'encoding': 'PNG'}
+        source = tilesource.SVSFileTileSource(os.path.join(
+            os.environ['LARGE_IMAGE_DATA'], 'sample_svs_image.TCGA-DU-6399-'
+            '01A-01-TS1.e8eb65de-d63e-42db-af6f-14fefbbdf7bd.svs'), **params)
+        self._testTilesZXY(source, tileMetadata, params, PNGHeader)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,16 @@
 enum34==1.1.2
-libtiff==0.4.0
+jsonschema==2.5.1
+repoze.lru==0.6
+six==1.10.0
+
+# Pillow is already required by another Girder plugin, but include it since we
+# can be installed by setup.py
+Pillow==3.1.0
 
 # https://github.com/DigitalSlideArchive/large_image/issues/30
 numpy==1.10.2
 
-# Pillow is already required by another Girder plugin
-#Pillow==3.1.0
-
-repoze.lru==0.6
+libtiff==0.4.0
 
 openslide-python>=1.1.0
 
-jsonschema==2.5.1

--- a/server/base.py
+++ b/server/base.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+###############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+###############################################################################
+
+from girder import events
+from girder.constants import AccessType
+from girder.utility.model_importer import ModelImporter
+
+from .rest import TilesItemResource, AnnotationResource
+from . import constants
+
+
+def _postUpload(event):
+    """
+    Called when a file is uploaded. We check the parent item to see if it is
+    expecting a large image upload, and if so we register this file as the
+    result image.
+    """
+    fileObj = event.info['file']
+    if 'itemId' not in fileObj:
+        return
+
+    Item = ModelImporter.model('item')
+    item = Item.load(fileObj['itemId'], force=True, exc=True)
+
+    if item.get('largeImage', {}).get('expected') and (
+            fileObj['name'].endswith('.tiff') or
+            fileObj.get('mimeType') == 'image/tiff'):
+        if fileObj.get('mimeType') != 'image/tiff':
+            fileObj['mimeType'] = 'image/tiff'
+            ModelImporter.model('file').save(fileObj)
+        del item['largeImage']['expected']
+        item['largeImage']['fileId'] = fileObj['_id']
+        item['largeImage']['sourceName'] = 'tiff'
+        Item.save(item)
+
+
+def validateSettings(event):
+    key, val = event.info['key'], event.info['value']
+
+    if key in (constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS,
+               constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER):
+        if str(val).lower() not in ('false', 'true', ''):
+            return
+        val = (str(val).lower() != 'false')
+    elif key == constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER:
+        val = str(val).strip()
+    else:
+        return
+    event.info['value'] = val
+    event.preventDefault().stopPropagation()
+
+
+def load(info):
+    TilesItemResource(info['apiRoot'])
+    info['apiRoot'].annotation = AnnotationResource()
+
+    ModelImporter.model('item').exposeFields(
+        level=AccessType.READ, fields='largeImage')
+    # Ask for the annotation model to make sure it is initialized.
+    ModelImporter.model('annotation', plugin='large_image')
+
+    events.bind('data.process', 'large_image', _postUpload)
+    events.bind('model.setting.validate', 'large_image', validateSettings)

--- a/server/base.py
+++ b/server/base.py
@@ -17,11 +17,10 @@
 #  limitations under the License.
 ###############################################################################
 
-from girder import events
+from girder import events, plugin
 from girder.constants import AccessType
 from girder.utility.model_importer import ModelImporter
 
-from .rest import TilesItemResource, AnnotationResource
 from . import constants
 
 
@@ -66,7 +65,15 @@ def validateSettings(event):
     event.preventDefault().stopPropagation()
 
 
+@plugin.config(
+    name='Large image',
+    description='Create, serve, and display large multiresolution images.',
+    version='0.2.0',
+    dependencies={'worker'},
+)
 def load(info):
+    from .rest import TilesItemResource, AnnotationResource
+
     TilesItemResource(info['apiRoot'])
     info['apiRoot'].annotation = AnnotationResource()
 

--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -54,9 +54,11 @@ class ImageItem(Item):
         item['largeImage']['fileId'] = fileObj['_id']
         job = None
         for sourceName in AvailableTileSources:
-            if AvailableTileSources[sourceName].canRead(item):
-                item['largeImage']['sourceName'] = sourceName
-                break
+            if getattr(AvailableTileSources[sourceName], 'girderSource',
+                       False):
+                if AvailableTileSources[sourceName].canRead(item):
+                    item['largeImage']['sourceName'] = sourceName
+                    break
         if 'sourceName' not in item['largeImage']:
             # No source was successful
             del item['largeImage']['fileId']

--- a/server/tilesource/__init__.py
+++ b/server/tilesource/__init__.py
@@ -21,8 +21,9 @@
 # flake8: noqa
 
 import collections
+import functools
 import sys
-from .base import TileSource, TileSourceException, \
+from .base import TileSource, getTileSourceFromDict, TileSourceException, \
     TileSourceAssetstoreException
 try:
     import girder
@@ -76,5 +77,11 @@ for source in sourceList:
             logger.exception('Error: Could not import %s' % className)
         else:
             logger.warning('Error: Could not import %s' % className)
+
+# Create a partial function that will work through the known functions to get a
+# tile source.
+getTileSource = functools.partial(getTileSourceFromDict,
+                                  AvailableTileSources)
+all.append(getTileSource)
 
 __all__ = all

--- a/server/tilesource/__init__.py
+++ b/server/tilesource/__init__.py
@@ -21,24 +21,40 @@
 # flake8: noqa
 
 import collections
-from girder.constants import TerminalColor
-from girder import logger
-
+import sys
 from .base import TileSource, TileSourceException, \
     TileSourceAssetstoreException
+try:
+    import girder
+    from girder.constants import TerminalColor
+    from girder import logger
+    from .base import GirderTileSource
+except ImportError:
+    import logging as logger
+    girder = None
+
 
 AvailableTileSources = collections.OrderedDict()
 all = [TileSource, TileSourceException, TileSourceAssetstoreException,
        AvailableTileSources]
 
+if girder:
+    all.append(GirderTileSource)
+
 sourceList = [
-    {'moduleName': '.tiff', 'className': 'TiffGirderTileSource'},
-    {'moduleName': '.svs', 'className': 'SVSGirderTileSource'},
+    {'moduleName': '.tiff', 'className': 'TiffFileTileSource'},
+    {'moduleName': '.tiff', 'className': 'TiffGirderTileSource',
+     'girder': True},
+    {'moduleName': '.svs', 'className': 'SVSFileTileSource'},
+    {'moduleName': '.svs', 'className': 'SVSGirderTileSource', 'girder': True},
     {'moduleName': '.test', 'className': 'TestTileSource'},
     {'moduleName': '.dummy', 'className': 'DummyTileSource'},
 ]
 for source in sourceList:
     try:
+        # Don't try to load girder sources if we couldn't import girder
+        if not girder and source.get('girder'):
+            continue
         # For each of our sources, try to import the named class from the
         # source module
         className = source['className']
@@ -55,7 +71,10 @@ for source in sourceList:
         if getattr(sourceClass, 'name', None):
             AvailableTileSources[sourceClass.name] = sourceClass
     except ImportError:
-        print(TerminalColor.error('Error: Could not import %s' % className))
-        logger.exception('Error: Could not import %s' % className)
+        if girder:
+            print(TerminalColor.error('Error: Could not import %s' % className))
+            logger.exception('Error: Could not import %s' % className)
+        else:
+            logger.warning('Error: Could not import %s' % className)
 
 __all__ = all

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -248,16 +248,17 @@ class TileSource(object):
 
     def getRegion(self, width=None, height=None, **kwargs):
         """
-        Get a basic thumbnail from the current tile source.  Aspect ratio is
-        preserved.  If neither width nor height is given, a default value is
-        used.  If both are given, the thumbnail will be no larger than either
-        size.
+        Get a rectangular region from the current tile source.  Aspect ratio is
+        preserved.  If neither width nor height is given, the original size of
+        the highest resolution level is used.  If both are given, the returned
+        image will be no larger than either size.
 
         :param width: maximum width in pixels.
         :param height: maximum height in pixels.
         :param **kwargs: optional arguments.  Some options are encoding,
-            jpegQuality, and jpegSubsampling.
-        :returns: thumbData, thumbMime: the image data and the mime type.
+            jpegQuality, jpegSubsampling, top, left, right, bottom,
+            regionWidth, regionHeight, units ('pixels' or 'fraction').
+        :returns: regionData, regionMime: the image data and the mime type.
         """
         if ((width is not None and width < 0) or
                 (height is not None and height < 0)):

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -27,6 +27,7 @@ try:
     from girder.utility import assetstore_utilities
     from girder.utility.model_importer import ModelImporter
     from ..models.base import TileGeneralException
+    from girder.models.model_base import AccessType
 except ImportError:
     import logging as logger
     girder = None
@@ -428,9 +429,9 @@ def getTileSourceFromDict(availableSources, pathOrUri, user=None, *args,
     sourceObj = pathOrUri
     uriWithoutProtocol = pathOrUri.split('://', 1)[-1]
     isGirder = pathOrUri.startswith('girder_item://')
-    if isGirder:
-        sourceObj = ModelImporter.model('item').load(uriWithoutProtocol,
-                                                     user=user)
+    if isGirder and girder:
+        sourceObj = ModelImporter.model('item').load(
+            uriWithoutProtocol, user=user, level=AccessType.READ)
     isLargeImageUri = pathOrUri.startswith('large_image://')
     for sourceName in availableSources:
         useSource = False

--- a/server/tilesource/svs.py
+++ b/server/tilesource/svs.py
@@ -134,6 +134,8 @@ class SVSFileTileSource(FileTileSource):
             })
 
     def getTile(self, x, y, z, pilImageAllowed=False, **kwargs):
+        if z < 0:
+            raise TileSourceException('z layer does not exist')
         try:
             svslevel = self._svslevels[z]
         except IndexError:

--- a/server/tilesource/svs.py
+++ b/server/tilesource/svs.py
@@ -26,39 +26,45 @@ from six.moves import range
 import openslide
 import PIL
 
-from .base import GirderTileSource, TileSourceException
+from .base import FileTileSource, TileSourceException
 from .cache import LruCacheMetaclass
+
+try:
+    import girder
+    from .base import GirderTileSource
+except ImportError:
+    girder = None
 
 
 @six.add_metaclass(LruCacheMetaclass)
-class SVSGirderTileSource(GirderTileSource):
+class SVSFileTileSource(FileTileSource):
     """
-    Provides tile access to Girder items with SVS file.
+    Provides tile access to SVS files.
     """
     cacheMaxSize = 2
     cacheTimeout = 60
-    name = 'svs'
+    name = 'svsfile'
 
     @staticmethod
     def cacheKeyFunc(args, kwargs):
-        item = args[0]
-        return (item.get('largeImage', {}).get('fileId'),
+        path = args[0]
+        return (path,
                 kwargs.get('jpegQuality'),
                 kwargs.get('jpegSubsampling'),
                 kwargs.get('encoding'))
 
-    def __init__(self, item, jpegQuality=95, jpegSubsampling=0,
+    def __init__(self, path, jpegQuality=95, jpegSubsampling=0,
                  encoding='JPEG', **kwargs):
         """
         Initialize the tile class.
 
-        :param item: the associated Girder item.
+        :param path: the associated file path.
         :param jpegQuality: when serving jpegs, use this quality.
         :param jpegSubsampling: when serving jpegs, use this subsampling (0 is
                                 full chroma, 1 is half, 2 is quarter).
         :param encoding: 'JPEG' or 'PNG'.
         """
-        super(SVSGirderTileSource, self).__init__(item, **kwargs)
+        super(SVSFileTileSource, self).__init__(path, **kwargs)
 
         if encoding not in ('PNG', 'JPEG'):
             raise ValueError('Invalid encoding "%s"' % encoding)
@@ -181,3 +187,21 @@ class SVSGirderTileSource(GirderTileSource):
             level += 1
             scale /= 2
         return level
+
+
+if girder:
+    class SVSGirderTileSource(SVSFileTileSource, GirderTileSource):
+        """
+        Provides tile access to Girder items with an SVS file.
+        """
+        cacheMaxSize = 2
+        cacheTimeout = 60
+        name = 'svs'
+
+        @staticmethod
+        def cacheKeyFunc(args, kwargs):
+            item = args[0]
+            return (item.get('largeImage', {}).get('fileId'),
+                    kwargs.get('jpegQuality'),
+                    kwargs.get('jpegSubsampling'),
+                    kwargs.get('encoding'))

--- a/server/tilesource/test.py
+++ b/server/tilesource/test.py
@@ -30,12 +30,13 @@ if int(PIL.PILLOW_VERSION.split('.')[0]) < 3:
 class TestTileSource(TileSource):
     name = 'test'
 
-    def __init__(self, minLevel=0, maxLevel=9,
+    def __init__(self, ignored_path=None, minLevel=0, maxLevel=9,
                  tileWidth=256, tileHeight=256, sizeX=None, sizeY=None,
                  fractal=False, encoding='PNG'):
         """
         Initialize the tile class.  The optional params options can include:
 
+        :param ignored_path: for compatibility with other sources.
         :param minLevel: minimum tile level
         :param maxLevel: maximum tile level
         :param tileWidth: tile width in pixels
@@ -87,7 +88,7 @@ class TestTileSource(TileSource):
                             ], color, None)
             sq /= 2
 
-    def getTile(self, x, y, z):
+    def getTile(self, x, y, z, *args, **kwargs):
         widthCount = 2 ** z
 
         if not (0 <= x < float(self.sizeX) / self.tileWidth * 2 ** (

--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -109,7 +109,7 @@ class TiledTiffDirectory(object):
         self._close()
         if not os.path.isfile(filePath):
             raise InvalidOperationTiffException(
-                'TIFF file does not exist: ' % filePath)
+                'TIFF file does not exist: %s' % filePath)
         try:
             self._tiffFile = libtiff_ctypes.TIFF.open(filePath)
         except TypeError:

--- a/setup.py
+++ b/setup.py
@@ -40,10 +40,19 @@ setup(
     packages=[
         'large_image',
         'large_image.server',
+        'large_image.server.models',
+        'large_image.server.rest',
+        'large_image.server.tilesource',
+    ],
+    data_files=[
+        ('large_image/girder', ['plugin.json']),
     ],
     package_dir={
         'large_image': 'large_image',
-        'large_image.server': 'server'
+        'large_image.server': 'server',
+    },
+    entry_points={
+        'girder.plugin': 'large_image = large_image.server:load'
     },
     classifiers=[
         'Development Status :: 3 - Alpha',
@@ -61,7 +70,7 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     license=license_str,
-    # zip_safe=True,  # Let setuptools decide, though it should be zip safe
+    # zip_safe=False,  # Comment out to let setuptools decide
     keywords='large_image',
     test_suite='plugin_tests',
     tests_require=test_requirements)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import json
+import pkg_resources
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
+with open('README.rst') as readme_file:
+    readme = readme_file.read()
+
+with open('plugin.json') as f:
+    pkginfo = json.load(f)
+
+with open('LICENSE') as f:
+    license_str = f.read()
+
+try:
+    with open('requirements.txt') as f:
+        ireqs = pkg_resources.parse_requirements(f.read())
+except pkg_resources.RequirementParseError:
+    raise
+requirements = [str(req) for req in ireqs]
+
+test_requirements = [
+    # TODO: Should we list Girder here?
+]
+
+setup(
+    name='large_image',
+    version=pkginfo['version'],
+    description=pkginfo['description'],
+    long_description=readme,
+    author='Kitware, Inc.',
+    author_email='developers@digitalslidearchive.net',
+    url='https://github.com/DigitalSlideArchive/large_image',
+    packages=[
+        'large_image',
+        'large_image.server',
+    ],
+    package_dir={
+        'large_image': 'large_image',
+        'large_image.server': 'server'
+    },
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Environment :: Console',
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4'
+        'Topic :: Software Development :: Libraries :: Python Modules',
+    ],
+
+    include_package_data=True,
+    install_requires=requirements,
+    license=license_str,
+    # zip_safe=True,  # Let setuptools decide, though it should be zip safe
+    keywords='large_image',
+    test_suite='plugin_tests',
+    tests_require=test_requirements)


### PR DESCRIPTION
Assuming you have the prerequisites, the tilesource can be used without girder.  To facilitate importing it from the source tree, when server is imported without girder, it will still work (though, naturally, you can't import server.models or server.rest).

The plugin_tests/girderless_test.py file shows some access of file sources without girder.