### PR TITLE
Fix test configuration error

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -45,8 +45,8 @@ add_eslint_test(
 )
 
 add_python_test(tiles PLUGIN large_image BIND_SERVER EXTERNAL_DATA
-  "sample_image.ptif" "plugins/large_image/sample_image.ptif"
-  "sample_svs_image.svs" "plugins/large_image/sample_svs_image.TCGA-DU-6399-01A-01-TS1.e8eb65de-d63e-42db-af6f-14fefbbdf7bd.svs"
+  "plugins/large_image/sample_image.ptif"
+  "plugins/large_image/sample_svs_image.TCGA-DU-6399-01A-01-TS1.e8eb65de-d63e-42db-af6f-14fefbbdf7bd.svs"
   )
 set_property(TEST server_large_image.tiles APPEND PROPERTY ENVIRONMENT
   "LARGE_IMAGE_DATA=${PROJECT_BINARY_DIR}/data/plugins/large_image")
@@ -54,8 +54,8 @@ set_property(TEST server_large_image.tiles APPEND PROPERTY ENVIRONMENT
 add_python_test(import PLUGIN large_image)
 
 add_python_test(girderless PLUGIN large_image BIND_SERVER EXTERNAL_DATA
-  "sample_image.ptif" "plugins/large_image/sample_image.ptif"
-  "sample_svs_image.svs" "plugins/large_image/sample_svs_image.TCGA-DU-6399-01A-01-TS1.e8eb65de-d63e-42db-af6f-14fefbbdf7bd.svs"
+  "plugins/large_image/sample_image.ptif"
+  "plugins/large_image/sample_svs_image.TCGA-DU-6399-01A-01-TS1.e8eb65de-d63e-42db-af6f-14fefbbdf7bd.svs"
   )
 set_property(TEST server_large_image.girderless APPEND PROPERTY ENVIRONMENT
   "LARGE_IMAGE_DATA=${PROJECT_BINARY_DIR}/data/plugins/large_image")


### PR DESCRIPTION
This commit fixes an error when configuring Girder tests due to EXTERNAL_DATA
referencing nonexistent files. For example:

    vagrant@isic-archive:~/girder-build$ cmake --version
    cmake version 2.8.12.2

    vagrant@isic-archive:~/girder-build$ cmake ../girder
    ...
    -- Including plugin.cmake from "large_image"
    CMake Error at /usr/share/cmake-2.8/Modules/ExternalData.cmake:434 (message):
      Data file referenced by argument

	DATA{/home/vagrant/girder-build/data_src/sample_image.ptif}

      corresponds to source tree path

	sample_image.ptif

      that does not exist as a file (with or without an extension)!
    Call Stack (most recent call first):
      /usr/share/cmake-2.8/Modules/ExternalData.cmake:255 (_ExternalData_arg)
      tests/TestData.cmake:105 (ExternalData_Expand_Arguments)
      tests/PythonTests.cmake:153 (girder_ExternalData_expand_arguments)
      plugins/large_image/plugin.cmake:47 (add_python_test)
      tests/CMakeLists.txt:90 (include)
      tests/CMakeLists.txt:105 (_add_plugin)

In the Travis environment these errors show up as warnings.