### PR TITLE
Automatically import svs and ptif files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ addons:
             - libsqlite3-dev
 
 before_install:
-    - GIRDER_VERSION=f6d29825c42295ca29e45a0f1164ffb070bc795c
+    - GIRDER_VERSION=084980c40d661a84a2c2c277672b92e9b3fbe254
     - GIRDER_WORKER_VERSION=508693448f97d4b8ee229429c4db6a89e4aa0d58
     - main_path=$PWD
     - build_path=$PWD/build

--- a/plugin_tests/cached_tiles_test.py
+++ b/plugin_tests/cached_tiles_test.py
@@ -289,9 +289,6 @@ class LargeImageCachedTilesTest(base.TestCase):
             os.environ['LARGE_IMAGE_DATA'], 'sample_jp2k_33003_TCGA-CV-7242-'
             '11A-01-TS1.1838afb1-9eee-4a70-9ae3-50e3ab45e242.svs'))
         itemId = str(file['itemId'])
-        resp = self.request(path='/item/%s/tiles' % itemId, method='POST',
-                            user=self.admin)
-        self.assertStatusOk(resp)
         # Get metadata to use in our tests
         resp = self.request(path='/item/%s/tiles' % itemId, user=self.admin)
         self.assertStatusOk(resp)

--- a/plugin_tests/largeImageSpec.js
+++ b/plugin_tests/largeImageSpec.js
@@ -54,6 +54,7 @@ describe('Test the large image plugin', function () {
             $('.g-large-image-thumbnails-hide').trigger('click');
             $('.g-large-image-viewer-hide').trigger('click');
             $('.g-large-image-default-viewer').val('geojs');
+            $('.g-large-image-auto-set-off').trigger('click');
             $('#g-large-image-form input.btn-primary').click();
         });
         waitsFor(function () {
@@ -65,6 +66,7 @@ describe('Test the large image plugin', function () {
             var settings = resp.responseJSON;
             return (settings['large_image.show_thumbnails'] === false &&
                     settings['large_image.show_viewer'] === false &&
+                    settings['large_image.auto_set'] === false &&
                     settings['large_image.default_viewer'] === 'geojs');
         }, 'large_image settings to change');
         girderTest.waitForLoad();

--- a/server/base.py
+++ b/server/base.py
@@ -57,10 +57,13 @@ def checkForLargeImageFiles(event):
     if mimeType in ('image/tiff', 'image/x-tiff', 'image/x-ptif'):
         possible = True
     exts = file.get('exts')
-    if isinstance(exts, list) and exts[-1] in (
+    if isinstance(exts, list) and len(exts) >= 1 and exts[-1] in (
             'svs', 'ptif', 'tif', 'tiff', 'ndpi'):
         possible = True
     if not file.get('itemId') or not possible:
+        return
+    if not ModelImporter.model('setting').get(
+            constants.PluginSettings.LARGE_IMAGE_AUTO_SET, True):
         return
     item = ModelImporter.model('item').load(
         file['itemId'], force=True, exc=False)
@@ -79,7 +82,8 @@ def validateSettings(event):
     key, val = event.info['key'], event.info['value']
 
     if key in (constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS,
-               constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER):
+               constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER,
+               constants.PluginSettings.LARGE_IMAGE_AUTO_SET):
         if str(val).lower() not in ('false', 'true', ''):
             return
         val = (str(val).lower() != 'false')

--- a/server/base.py
+++ b/server/base.py
@@ -57,8 +57,7 @@ def checkForLargeImageFiles(event):
     if mimeType in ('image/tiff', 'image/x-tiff', 'image/x-ptif'):
         possible = True
     exts = file.get('exts')
-    if isinstance(exts, list) and len(exts) >= 1 and exts[-1] in (
-            'svs', 'ptif', 'tif', 'tiff', 'ndpi'):
+    if exts and exts[-1] in ('svs', 'ptif', 'tif', 'tiff', 'ndpi'):
         possible = True
     if not file.get('itemId') or not possible:
         return

--- a/server/base.py
+++ b/server/base.py
@@ -57,10 +57,9 @@ def checkForLargeImageFiles(event):
     if mimeType in ('image/tiff', 'image/x-tiff', 'image/x-ptif'):
         possible = True
     exts = file.get('exts')
-    if isinstance(exts, list):
-        for ext in exts:
-            if ext in ('svs', 'ptif', 'tif', 'tiff'):
-                possible = True
+    if isinstance(exts, list) and exts[-1] in (
+            'svs', 'ptif', 'tif', 'tiff', 'ndpi'):
+        possible = True
     if not file.get('itemId') or not possible:
         return
     item = ModelImporter.model('item').load(

--- a/server/constants.py
+++ b/server/constants.py
@@ -23,3 +23,4 @@ class PluginSettings:
     LARGE_IMAGE_SHOW_THUMBNAILS = 'large_image.show_thumbnails'
     LARGE_IMAGE_SHOW_VIEWER = 'large_image.show_viewer'
     LARGE_IMAGE_DEFAULT_VIEWER = 'large_image.default_viewer'
+    LARGE_IMAGE_AUTO_SET = 'large_image.auto_set'

--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -34,7 +34,8 @@ class ImageItem(Item):
     def initialize(self):
         super(ImageItem, self).initialize()
 
-    def createImageItem(self, item, fileObj, user=None, token=None):
+    def createImageItem(self, item, fileObj, user=None, token=None,
+                        createJob=True):
         # Using setdefault ensures that 'largeImage' is in the item
         if 'fileId' in item.setdefault('largeImage', {}):
             # TODO: automatically delete the existing large file
@@ -58,6 +59,9 @@ class ImageItem(Item):
                 if AvailableTileSources[sourceName].canRead(item):
                     item['largeImage']['sourceName'] = sourceName
                     break
+        if 'sourceName' not in item['largeImage'] and not createJob:
+            raise TileGeneralException(
+                'A job must be used to generate a largeImage.')
         if 'sourceName' not in item['largeImage']:
             # No source was successful
             del item['largeImage']['fileId']

--- a/server/rest/tiles.py
+++ b/server/rest/tiles.py
@@ -360,5 +360,6 @@ class TilesItemResource(Item):
             constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS,
             constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER,
             constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER,
+            constants.PluginSettings.LARGE_IMAGE_AUTO_SET,
         ]
         return {k: self.model('setting').get(k) for k in keys}

--- a/web_client/js/configView.js
+++ b/web_client/js/configView.js
@@ -15,6 +15,9 @@ girder.views.largeImageConfig = girder.View.extend({
             }, {
                 key: 'large_image.default_viewer',
                 value: this.$('.g-large-image-default-viewer').val()
+            }, {
+                key: 'large_image.auto_set',
+                value: this.$('.g-large-image-auto-set-on').prop('checked')
             }]);
         }
     },

--- a/web_client/stylesheets/largeImageConfig.styl
+++ b/web_client/stylesheets/largeImageConfig.styl
@@ -1,0 +1,4 @@
+#g-large-image-form
+  .g-large-image-description
+    font-size 12px
+    margin 0 0 2px 0

--- a/web_client/templates/largeImageConfig.jade
+++ b/web_client/templates/largeImageConfig.jade
@@ -5,27 +5,38 @@ p.g-large-image-description
 form#g-large-image-form(role="form")
   .form-group
     label Large image thumbnails in item lists
-      .g-large-image-thumbnails-container
-        label.radio-inline
-          input.g-large-image-thumbnails-show(type="radio" name="g-large-image-thumbnails" checked=(settings['large_image.show_thumbnails'] !== false ? 'checked': undefined))
-          | Show thumbnails
-        label.radio-inline
-          input.g-large-image-thumbnails-hide(type="radio" name="g-large-image-thumbnails" checked=(settings['large_image.show_thumbnails'] !== false ? undefined : 'checked'))
-          | Don't show
+    .g-large-image-thumbnails-container
+      label.radio-inline
+        input.g-large-image-thumbnails-show(type="radio" name="g-large-image-thumbnails" checked=(settings['large_image.show_thumbnails'] !== false ? 'checked': undefined))
+        | Show thumbnails
+      label.radio-inline
+        input.g-large-image-thumbnails-hide(type="radio" name="g-large-image-thumbnails" checked=(settings['large_image.show_thumbnails'] !== false ? undefined : 'checked'))
+        | Don't show
   .form-group
     label Large images in items
-      .g-large-image-viewer-container
-        label.radio-inline
-          input.g-large-image-viewer-show(type="radio" name="g-large-image-viewer" checked=(settings['large_image.show_viewer'] !== false ? 'checked': undefined))
-          | Show viewer
-        label.radio-inline
-          input.g-large-image-viewer-hide(type="radio" name="g-large-image-viewer" checked=(settings['large_image.show_viewer'] !== false ? undefined : 'checked'))
-          | Don't show
+    .g-large-image-viewer-container
+      label.radio-inline
+        input.g-large-image-viewer-show(type="radio" name="g-large-image-viewer" checked=(settings['large_image.show_viewer'] !== false ? 'checked': undefined))
+        | Show viewer
+      label.radio-inline
+        input.g-large-image-viewer-hide(type="radio" name="g-large-image-viewer" checked=(settings['large_image.show_viewer'] !== false ? undefined : 'checked'))
+        | Don't show
   .form-group
     label Default large image item viewer 
-      .g-large-image-default-viewer-container
-        select.form-control.input-sm.g-large-image-default-viewer
-          each viewer in viewers
-            option(value=viewer.name, selected=(settings['large_image.default_viewer'] === viewer.name)) #{viewer.label}
+    .g-large-image-default-viewer-container
+      select.form-control.input-sm.g-large-image-default-viewer
+        each viewer in viewers
+          option(value=viewer.name, selected=(settings['large_image.default_viewer'] === viewer.name)) #{viewer.label}
+  .form-group
+    label Automatically use new items as large images
+    p.g-large-image-description
+      | Uploaded and imported items with files that have mime-types or extensions that are typical of large images will be set as large image items if they can be used without running a conversion job.
+    .g-large-image-auto-set-container
+      label.radio-inline
+        input.g-large-image-auto-set-on(type="radio" name="g-large-image-auto-set" checked=(settings['large_image.auto_set'] !== false ? 'checked': undefined))
+        | Automatically use large images
+      label.radio-inline
+        input.g-large-image-auto-set-off(type="radio" name="g-large-image-auto-set" checked=(settings['large_image.auto_set'] !== false ? undefined : 'checked'))
+        | No automatic use
   p#g-large-image-error-message.g-validation-failed-message
   input.btn.btn-sm.btn-primary(type="submit", value="Save")

--- a/web_client/templates/largeImageConfig.jade
+++ b/web_client/templates/largeImageConfig.jade
@@ -30,7 +30,7 @@ form#g-large-image-form(role="form")
   .form-group
     label Automatically use new items as large images
     p.g-large-image-description
-      | Uploaded and imported items with files that have mime-types or extensions that are typical of large images will be set as large image items if they can be used without running a conversion job.
+      | Uploaded and imported items with files that have MIME-types or extensions that are typical of large images will be set as large image items if they can be used without running a conversion job.
     .g-large-image-auto-set-container
       label.radio-inline
         input.g-large-image-auto-set-on(type="radio" name="g-large-image-auto-set" checked=(settings['large_image.auto_set'] !== false ? 'checked': undefined))


### PR DESCRIPTION
Any file that has a TIFF mime type or a file extension that is one of ptif, tif, tiff, svs is checked.  If it can be used as a large_image without a conversion job, it is so marked.

This resolves issue #65.