### PR TITLE
Filter cherrypy access logs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ addons:
             - libsqlite3-dev
 
 before_install:
-    - GIRDER_VERSION=f6d29825c42295ca29e45a0f1164ffb070bc795c
+    - GIRDER_VERSION=73adf725c40169f57b24d2ea2fbbfe99e0c33364
     - GIRDER_WORKER_VERSION=508693448f97d4b8ee229429c4db6a89e4aa0d58
     - main_path=$PWD
     - build_path=$PWD/build

--- a/server/cache_util/cachefactory.py
+++ b/server/cache_util/cachefactory.py
@@ -22,11 +22,11 @@ import threading
 import math
 # attempt to import girder config
 try:
-    from girder import constants
+    from girder import logprint
     from girder.utility import config
 except ImportError:
+    import logging as logprint
     config = None
-    constants = None
 
 from .memcache import MemCache
 from cachetools import LRUCache
@@ -92,7 +92,5 @@ class CacheFactory():
                 portion = 16
             tileCache = LRUCache(pickAvailableCache(256**2 * 4, portion))
             tileCacheLock = None
-        if constants:
-            print(constants.TerminalColor.info(
-                'Using %s for large_image caching' % cacheBackend))
+        logprint.info('Using %s for large_image caching' % cacheBackend)
         return tileCache, tileCacheLock

--- a/server/cache_util/memcache.py
+++ b/server/cache_util/memcache.py
@@ -21,6 +21,11 @@ from cachetools import Cache, hashkey
 import pylibmc
 import hashlib
 
+try:
+    from girder import logprint
+except ImportError:
+    import logging as logprint
+
 
 def strhash(*args, **kwargs):
     return str(hashkey(*args, **kwargs))
@@ -76,9 +81,10 @@ class MemCache(Cache):
         try:
             self._Cache__data[hexVal] = value
         except KeyError:
-            print('Failed to save value %s with key %s' % (value, hexVal))
+            logprint.error('Failed to save value %s with key %s' % (
+                value, hexVal))
         except pylibmc.Error as exc:
-            # memcahced won't cache items larger than 1 Mb, but this returns a
+            # memcached won't cache items larger than 1 Mb, but this returns a
             # 'SUCCESS' error.  Raise other errors.
             if 'SUCCESS' not in exc.message:
                 raise

--- a/server/rest/tiles.py
+++ b/server/rest/tiles.py
@@ -52,7 +52,8 @@ class TilesItemResource(Item):
         apiRoot.item.route('GET', ('test', 'tiles', 'zxy', ':z', ':x', ':y'),
                            self.getTestTile)
         filter_logging.addLoggingFilter(
-            'GET (/[^/ ?#]+)*/item/[^/ ?#]+/tiles/zxy(/[^/ ?#]+){3}', 250)
+            'GET (/[^/ ?#]+)*/item/[^/ ?#]+/tiles/zxy(/[^/ ?#]+){3}',
+            frequency=250)
         # This is added to the system route
         apiRoot.system.route('GET', ('setting', 'large_image'),
                              self.getPublicSettings)

--- a/server/rest/tiles.py
+++ b/server/rest/tiles.py
@@ -19,7 +19,7 @@
 
 import cherrypy
 
-from girder.api import access
+from girder.api import access, filter_logging
 from girder.api.v1.item import Item
 from girder.api.describe import describeRoute, Description
 from girder.api.rest import filtermodel, loadmodel, RestException, \
@@ -51,6 +51,8 @@ class TilesItemResource(Item):
         apiRoot.item.route('GET', ('test', 'tiles'), self.getTestTilesInfo)
         apiRoot.item.route('GET', ('test', 'tiles', 'zxy', ':z', ':x', ':y'),
                            self.getTestTile)
+        filter_logging.addLoggingFilter(
+            'GET (/[^/ ?#]+)*/item/[^/ ?#]+/tiles/zxy(/[^/ ?#]+){3}', 250)
         # This is added to the system route
         apiRoot.system.route('GET', ('setting', 'large_image'),
                              self.getPublicSettings)

--- a/server/tilesource/__init__.py
+++ b/server/tilesource/__init__.py
@@ -28,10 +28,10 @@ from .base import TileSource, getTileSourceFromDict, TileSourceException, \
 try:
     import girder
     from girder.constants import TerminalColor
-    from girder import logger
+    from girder import logprint
     from .base import GirderTileSource
 except ImportError:
-    import logging as logger
+    import logging as logprint
     girder = None
 
 
@@ -72,11 +72,7 @@ for source in sourceList:
         if getattr(sourceClass, 'name', None):
             AvailableTileSources[sourceClass.name] = sourceClass
     except ImportError:
-        if girder:
-            print(TerminalColor.error('Error: Could not import %s' % className))
-            logger.exception('Error: Could not import %s' % className)
-        else:
-            logger.warning('Error: Could not import %s' % className)
+        logprint.exception('Error: Could not import %s' % className)
 
 # Create a partial function that will work through the known functions to get a
 # tile source.


### PR DESCRIPTION
Only log 1 out of 250 tile messages.

Also, switch to the new logprint function for print statements.

Resolves issue #66.