### PR TITLE
When a job fails or is canceled, update the large image item to reflect that.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: python
 
 python:
-    - "2.7"
+  - "2.7"
 
 cache:
-    directories:
-        - $HOME/.cache
+  directories:
+    - $HOME/.cache
+    - $HOME/build/girder_testing_build/store
+    - $HOME/build/girder_testing_build/data
 
 # sudo: false
 sudo: required
@@ -13,123 +15,127 @@ sudo: required
 dist: trusty
 
 compiler:
-    - gcc
+  - gcc
 
 addons:
-    apt:
-        packages:
-            # Pillow dependencies (see
-            # https://pillow.readthedocs.org/en/latest/installation.html)
-            - libtiff5-dev
-            - libjpeg8-dev
-            - zlib1g-dev
-            - libfreetype6-dev
-            - liblcms2-dev
-            - libwebp-dev
-            - tcl8.6-dev
-            - tk8.6-dev
-            - python-tk
-            # vips
-            - libvips-tools
-            # openjpeg
-            - libglib2.0-dev
-            - libjpeg-dev
-            - libxml2-dev
-            - libpng12-dev
-            # openslide
-            - autoconf
-            - automake
-            - libtool
-            - pkg-config
-            - libcairo2-dev
-            - libgdk-pixbuf2.0-dev
-            - libxml2-dev 
-            - libsqlite3-dev
+  apt:
+    packages:
+      # Pillow dependencies (see
+      # https://pillow.readthedocs.org/en/latest/installation.html)
+      - libtiff5-dev
+      - libjpeg8-dev
+      - zlib1g-dev
+      - libfreetype6-dev
+      - liblcms2-dev
+      - libwebp-dev
+      - tcl8.6-dev
+      - tk8.6-dev
+      - python-tk
+      # vips
+      - libvips-tools
+      # openjpeg
+      - libglib2.0-dev
+      - libjpeg-dev
+      - libxml2-dev
+      - libpng12-dev
+      # openslide
+      - autoconf
+      - automake
+      - libtool
+      - pkg-config
+      - libcairo2-dev
+      - libgdk-pixbuf2.0-dev
+      - libxml2-dev 
+      - libsqlite3-dev
 
 before_install:
-    - GIRDER_VERSION=4ee695152af8817df26cde7f1987cabcc2057615
-    - GIRDER_WORKER_VERSION=508693448f97d4b8ee229429c4db6a89e4aa0d58
-    - main_path=$PWD
-    - build_path=$PWD/build
-    - mkdir -p $build_path
+  - GIRDER_VERSION=4ee695152af8817df26cde7f1987cabcc2057615
+  - GIRDER_WORKER_VERSION=508693448f97d4b8ee229429c4db6a89e4aa0d58
+  - main_path=$PWD
+  - build_path=$PWD/build
+  - mkdir -p $build_path
 
-    - girder_path=$build_path/girder
-    - rm -fr $girder_path
-    - git clone https://github.com/girder/girder.git $girder_path && git -C $girder_path checkout $GIRDER_VERSION
-    - ln -sf $main_path $girder_path/plugins/
-    - ls -l $girder_path/plugins
+  - girder_path=$build_path/girder
+  - rm -fr $girder_path
+  - git clone https://github.com/girder/girder.git $girder_path && git -C $girder_path checkout $GIRDER_VERSION
+  - ln -sf $main_path $girder_path/plugins/
+  - ls -l $girder_path/plugins
 
-    - CACHE=$HOME/.cache CMAKE_VERSION=3.1.0 CMAKE_SHORT_VERSION=3.1 source $girder_path/scripts/install_cmake.sh
-    - cmake --version
+  - CACHE=$HOME/.cache CMAKE_VERSION=3.1.0 CMAKE_SHORT_VERSION=3.1 source $girder_path/scripts/install_cmake.sh
+  - cmake --version
 
-    # There is an issue with the OpenJPEG library included with Ubuntu 14.04,
-    # so install it from source.
-    - cd $build_path
-    # - wget -O openjpeg-2.1.tar.gz https://github.com/uclouvain/openjpeg/archive/version.2.1.tar.gz
-    # - tar -zxf openjpeg-2.1.tar.gz
-    # - cd openjpeg-version.2.1
-    - wget -O openjpeg-1.5.2.tar.gz https://github.com/uclouvain/openjpeg/archive/version.1.5.2.tar.gz
-    - tar -zxf openjpeg-1.5.2.tar.gz
-    - cd openjpeg-version.1.5.2
-    - cmake .
-    - make
-    - sudo make install
-    - sudo ldconfig
-    - cd $main_path
+  # There is an issue with the OpenJPEG library included with Ubuntu 14.04,
+  # so install it from source.
+  - cd $build_path
+  # - wget -O openjpeg-2.1.tar.gz https://github.com/uclouvain/openjpeg/archive/version.2.1.tar.gz
+  # - tar -zxf openjpeg-2.1.tar.gz
+  # - cd openjpeg-version.2.1
+  - wget -O openjpeg-1.5.2.tar.gz https://github.com/uclouvain/openjpeg/archive/version.1.5.2.tar.gz
+  - tar -zxf openjpeg-1.5.2.tar.gz
+  - cd openjpeg-version.1.5.2
+  - cmake .
+  - make
+  - sudo make install
+  - sudo ldconfig
+  - cd $main_path
 
-    # Build libtiff so it will use our openjpeg
-    - cd $build_path
-    - wget http://download.osgeo.org/libtiff/tiff-4.0.3.tar.gz
-    - tar -zxf tiff-4.0.3.tar.gz
-    - cd tiff-4.0.3
-    - ./configure
-    - make
-    - sudo make install
-    - sudo ldconfig
-    - cd $main_path
+  # Build libtiff so it will use our openjpeg
+  - cd $build_path
+  - wget http://download.osgeo.org/libtiff/tiff-4.0.3.tar.gz
+  - tar -zxf tiff-4.0.3.tar.gz
+  - cd tiff-4.0.3
+  - ./configure
+  - make
+  - sudo make install
+  - sudo ldconfig
+  - cd $main_path
 
-    # Build OpenSlide ourselves so that it will use our libtiff
-    - cd $build_path
-    - wget -O openslide-3.4.1.tar.gz https://github.com/openslide/openslide/archive/v3.4.1.tar.gz
-    - tar -zxf openslide-3.4.1.tar.gz
-    - cd openslide-3.4.1
-    - autoreconf -i
-    - ./configure
-    - make
-    - sudo make install
-    - sudo ldconfig
-    - cd $main_path
+  # Build OpenSlide ourselves so that it will use our libtiff
+  - cd $build_path
+  - wget -O openslide-3.4.1.tar.gz https://github.com/openslide/openslide/archive/v3.4.1.tar.gz
+  - tar -zxf openslide-3.4.1.tar.gz
+  - cd openslide-3.4.1
+  - autoreconf -i
+  - ./configure
+  - make
+  - sudo make install
+  - sudo ldconfig
+  - cd $main_path
 
-    - girder_worker_path=$girder_path/plugins/girder_worker
-    - git clone https://github.com/girder/girder_worker.git $girder_worker_path && git -C $girder_worker_path checkout $GIRDER_WORKER_VERSION
-    - cp $PWD/plugin_tests/test_files/girder_worker.cfg $girder_worker_path/girder_worker/worker.local.cfg
-    - pip install --no-cache-dir -U -r $girder_worker_path/requirements.txt -r $girder_worker_path/girder_worker/plugins/girder_io/requirements.txt
+  - girder_worker_path=$girder_path/plugins/girder_worker
+  - git clone https://github.com/girder/girder_worker.git $girder_worker_path && git -C $girder_worker_path checkout $GIRDER_WORKER_VERSION
+  - cp $PWD/plugin_tests/test_files/girder_worker.cfg $girder_worker_path/girder_worker/worker.local.cfg
+  - pip install --no-cache-dir -U -r $girder_worker_path/requirements.txt -r $girder_worker_path/girder_worker/plugins/girder_io/requirements.txt
 
-    - export MONGO_VERSION=3.0.7
-    - export PY_COVG="ON"
-    - CACHE=$HOME/.cache source $girder_path/scripts/install_mongo.sh
-    - mkdir /tmp/db
-    - mongod --dbpath=/tmp/db >/dev/null 2>/dev/null &
-    - mongod --version
+  - export MONGO_VERSION=3.0.7
+  - export PY_COVG="ON"
+  - CACHE=$HOME/.cache source $girder_path/scripts/install_mongo.sh
+  - mkdir /tmp/db
+  - mongod --dbpath=/tmp/db >/dev/null 2>/dev/null &
+  - mongod --version
 
-    - npm install -g npm
-    - npm --version
+  - npm install -g npm
+  - npm --version
 
-    - pip install --no-cache-dir -U pip virtualenv
+  - pip install --no-cache-dir -U pip virtualenv
 
-    - pip install --no-cache-dir numpy==1.10.2  # needed because libtiff doesn't install correctly without it.  This ensures we have the same version for libtiff as for the project.
+  - pip install --no-cache-dir numpy==1.10.2  # needed because libtiff doesn't install correctly without it.  This ensures we have the same version for libtiff as for the project.
 
 install:
-    - cd $girder_path
-    - pip install --no-cache-dir -U -r requirements.txt -r requirements-dev.txt -r $main_path/requirements.txt -e .
-    - python -c "import openslide;print openslide.__version__"
-    - npm install
+  - cd $girder_path
+  - pip install --no-cache-dir -U -r requirements.txt -r requirements-dev.txt -r $main_path/requirements.txt -e .
+  - python -c "import openslide;print openslide.__version__"
+  - npm install
 
 script:
-    - cd $girder_worker_path
-    - python -m girder_worker &
-    - mkdir -p $build_path/girder_testing_build
-    - cd $build_path/girder_testing_build
-    - cmake -DPYTHON_COVERAGE:BOOL=${PY_COVG} -DPYTHON_VERSION:STRING=${TRAVIS_PYTHON_VERSION} $girder_path
-    - make
-    - JASMINE_TIMEOUT=15000 ctest -VV -R large_image
+  - cd $girder_worker_path
+  - python -m girder_worker >/tmp/worker.out 2>&1 &
+  - mkdir -p $build_path/girder_testing_build
+  - cd $build_path/girder_testing_build
+  - cmake -DPYTHON_COVERAGE:BOOL=${PY_COVG} -DPYTHON_VERSION:STRING=${TRAVIS_PYTHON_VERSION} $girder_path
+  - make
+  - JASMINE_TIMEOUT=15000 ctest -VV -R large_image
+
+after_failure:
+  # On failures, show girder's error long and the worker output
+  - cat /tmp/worker.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,10 +47,15 @@ addons:
       - libgdk-pixbuf2.0-dev
       - libxml2-dev 
       - libsqlite3-dev
+      # girder worker
+      - rabbitmq-server
+
+services:
+  - rabbitmq
 
 before_install:
-  - GIRDER_VERSION=4ee695152af8817df26cde7f1987cabcc2057615
-  - GIRDER_WORKER_VERSION=508693448f97d4b8ee229429c4db6a89e4aa0d58
+  - GIRDER_VERSION=cb846cee604b07368800e99322c7347039a2a464
+  - GIRDER_WORKER_VERSION=2cfb739c096c2373f8bbe00853e3709f433192a6
   - main_path=$PWD
   - build_path=$PWD/build
   - mkdir -p $build_path
@@ -74,7 +79,7 @@ before_install:
   - tar -zxf openjpeg-1.5.2.tar.gz
   - cd openjpeg-version.1.5.2
   - cmake .
-  - make
+  - make -j 3
   - sudo make install
   - sudo ldconfig
   - cd $main_path
@@ -85,7 +90,7 @@ before_install:
   - tar -zxf tiff-4.0.3.tar.gz
   - cd tiff-4.0.3
   - ./configure
-  - make
+  - make -j 3
   - sudo make install
   - sudo ldconfig
   - cd $main_path
@@ -97,7 +102,7 @@ before_install:
   - cd openslide-3.4.1
   - autoreconf -i
   - ./configure
-  - make
+  - make -j 3
   - sudo make install
   - sudo ldconfig
   - cd $main_path
@@ -133,7 +138,7 @@ script:
   - mkdir -p $build_path/girder_testing_build
   - cd $build_path/girder_testing_build
   - cmake -DPYTHON_COVERAGE:BOOL=${PY_COVG} -DPYTHON_VERSION:STRING=${TRAVIS_PYTHON_VERSION} $girder_path
-  - make
+  - make -j 3
   - JASMINE_TIMEOUT=15000 ctest -VV -R large_image
 
 after_failure:

--- a/plugin_tests/cached_tiles_test.py
+++ b/plugin_tests/cached_tiles_test.py
@@ -124,10 +124,10 @@ class LargeImageCachedTilesTest(base.TestCase):
             '/system/setting', method='PUT', user=self.admin, params={
                 'list': json.dumps([{
                     'key': 'worker.broker',
-                    'value': 'mongodb://127.0.0.1/girder_worker'
+                    'value': 'amqp://guest@127.0.0.1/'
                     }, {
                     'key': 'worker.backend',
-                    'value': 'mongodb://127.0.0.1/girder_worker'
+                    'value': 'amqp://guest@127.0.0.1/'
                     }])})
         self.assertStatusOk(resp)
 

--- a/plugin_tests/test_files/girder_worker.cfg
+++ b/plugin_tests/test_files/girder_worker.cfg
@@ -1,6 +1,6 @@
 [celery]
 app_main=girder_worker
-broker=mongodb://127.0.0.1/girder_worker
+broker=amqp://guest@127.0.0.1/
 
 [girder_worker]
 # Root dir where temp files for jobs will be written

--- a/plugin_tests/test_files/girder_worker.cfg
+++ b/plugin_tests/test_files/girder_worker.cfg
@@ -1,6 +1,6 @@
 [celery]
 app_main=girder_worker
-broker=mongodb://localhost/girder_worker
+broker=mongodb://127.0.0.1/girder_worker
 
 [girder_worker]
 # Root dir where temp files for jobs will be written

--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -69,10 +69,10 @@ class LargeImageTilesTest(base.TestCase):
             '/system/setting', method='PUT', user=self.admin, params={
                 'list': json.dumps([{
                     'key': 'worker.broker',
-                    'value': 'mongodb://127.0.0.1/girder_worker'
+                    'value': 'amqp://guest@127.0.0.1/'
                     }, {
                     'key': 'worker.backend',
-                    'value': 'mongodb://127.0.0.1/girder_worker'
+                    'value': 'amqp://guest@127.0.0.1/'
                     }])})
         self.assertStatusOk(resp)
 

--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -252,6 +252,8 @@ class LargeImageTilesTest(base.TestCase):
             except AssertionError as exc:
                 if 'File must have at least 1 level' in exc.args[0]:
                     return False
+                if 'No large image file' in exc.args[0]:
+                    return None
                 self.assertIn('is still pending creation', exc.args[0])
             item = self.model('item').load(itemId, user=self.admin)
             job = self.model('job', 'jobs').load(item['largeImage']['jobId'],
@@ -470,7 +472,7 @@ class LargeImageTilesTest(base.TestCase):
         resp = self.request(path='/item/%s/tiles' % itemId, method='DELETE',
                             user=self.admin)
         self.assertStatusOk(resp)
-        self.assertEqual(resp.json['deleted'], True)
+        self.assertEqual(resp.json['deleted'], False)
 
     def testTilesFromSVS(self):
         file = self._uploadFile(os.path.join(

--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -25,7 +25,6 @@ import struct
 import time
 from six.moves import range
 
-import girder
 from girder import config
 from tests import base
 
@@ -257,11 +256,6 @@ class LargeImageTilesTest(base.TestCase):
                 if 'No large image file' in exc.args[0]:
                     return None
                 self.assertIn('is still pending creation', exc.args[0])
-            item = self.model('item').load(itemId, user=self.admin)
-            job = self.model('job', 'jobs').load(item['largeImage']['jobId'],
-                                                 user=self.admin)
-            if job['status'] == girder.plugins.jobs.constants.JobStatus.ERROR:
-                return None
             time.sleep(0.1)
         self.assertStatusOk(resp)
         return resp.json

--- a/server/base.py
+++ b/server/base.py
@@ -70,6 +70,19 @@ def _updateJob(event):
         return
     if item.get('largeImage', {}).get('expected'):
         del item['largeImage']['expected']
+    notify = item.get('largeImage', {}).get('notify')
+    if notify:
+        del item['largeImage']['notify']
+        if job['status'] == JobStatus.SUCCESS:
+            msg = 'Large image created'
+        elif job['status'] == JobStatus.CANCELED:
+            msg = 'Large image creation canceled'
+        else:  # ERROR
+            msg = 'FAILED: Large image creation failed'
+        msg += ' for item %s' % item['name']
+        if not job.get('progress') or job['progress'].get('message') != msg:
+            ModelImporter.model('job', 'jobs').updateJob(
+                job, notify=True, progressMessage=msg)
     if (job['status'] in (JobStatus.ERROR, JobStatus.CANCELED) and
             'largeImage' in item):
         del item['largeImage']

--- a/server/base.py
+++ b/server/base.py
@@ -64,8 +64,7 @@ def _updateJob(event):
     status = job['status']
     if status not in (JobStatus.ERROR, JobStatus.CANCELED, JobStatus.SUCCESS):
         return
-    item = ModelImporter.model('item').load(meta['itemId'], force=True,
-                                            exc=False)
+    item = ModelImporter.model('item').load(meta['itemId'], force=True)
     if not item or 'largeImage' not in item:
         return
     if item.get('largeImage', {}).get('expected'):

--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -35,7 +35,7 @@ class ImageItem(Item):
         super(ImageItem, self).initialize()
 
     def createImageItem(self, item, fileObj, user=None, token=None,
-                        createJob=True):
+                        createJob=True, notify=False):
         # Using setdefault ensures that 'largeImage' is in the item
         if 'fileId' in item.setdefault('largeImage', {}):
             # TODO: automatically delete the existing large file
@@ -67,6 +67,7 @@ class ImageItem(Item):
             del item['largeImage']['fileId']
             job = self._createLargeImageJob(item, fileObj, user, token)
             item['largeImage']['expected'] = True
+            item['largeImage']['notify'] = notify
             item['largeImage']['originalId'] = fileObj['_id']
             item['largeImage']['jobId'] = job['_id']
 

--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -113,7 +113,7 @@ class ImageItem(Item):
 
         inputs = {
             'in_path': workerUtils.girderInputSpec(
-                item, resourceType='item', token=token),
+                fileObj, resourceType='file', token=token),
             'quality': {
                 'mode': 'inline',
                 'type': 'number',
@@ -147,6 +147,11 @@ class ImageItem(Item):
             'jobInfo': workerUtils.jobInfoSpec(job, jobToken),
             'auto_convert': False,
             'validate': False
+        }
+        job['meta'] = {
+            'creator': 'large_image',
+            'itemId': str(item['_id']),
+            'task': 'createImageItem',
         }
 
         job = Job.save(job)

--- a/server/rest/tiles.py
+++ b/server/rest/tiles.py
@@ -66,6 +66,9 @@ class TilesItemResource(Item):
         .param('fileId', 'The ID of the source file containing the image. '
                          'Required if there is more than one file in the item.',
                required=False)
+        .param('notify', 'If a job is required to create the large image, '
+               'a nofication can be sent when it is complete.',
+               dataType='boolean', default=True, required=False)
     )
     @access.user
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.WRITE)
@@ -85,7 +88,8 @@ class TilesItemResource(Item):
         token = self.getCurrentToken()
         try:
             return self.imageItemModel.createImageItem(
-                item, largeImageFile, user, token)
+                item, largeImageFile, user, token,
+                notify=self.boolParam('notify', params, default=True))
         except TileGeneralException as e:
             raise RestException(e.message)
 

--- a/web_client/js/fileList.js
+++ b/web_client/js/fileList.js
@@ -37,7 +37,7 @@ girder.wrap(girder.views.FileListWidget, 'render', function (render) {
         girder.restRequest({
             type: 'POST',
             path: 'item/' + this.parentItem.id + '/tiles',
-            data: {fileId: fileId},
+            data: {fileId: fileId, notify: true},
             error: function (error) {
                 if (error.status !== 0) {
                     girder.events.trigger('g:alert', {


### PR DESCRIPTION
Send a file to the processing job rather than an item.  This allows processing an image from an item that has more than one file.

This change was prompted by trying to convert a file with a name that differed from its containing item in a non-filesystem assetstore.