### PR TITLE
Store thumbnails in files

### DIFF
--- a/plugin_tests/largeImageSpec.js
+++ b/plugin_tests/largeImageSpec.js
@@ -55,6 +55,7 @@ describe('Test the large image plugin', function () {
             $('.g-large-image-viewer-hide').trigger('click');
             $('.g-large-image-default-viewer').val('geojs');
             $('.g-large-image-auto-set-off').trigger('click');
+            $('.g-large-image-max-thumbnail-files').val('5');
             $('#g-large-image-form input.btn-primary').click();
         });
         waitsFor(function () {
@@ -67,7 +68,8 @@ describe('Test the large image plugin', function () {
             return (settings['large_image.show_thumbnails'] === false &&
                     settings['large_image.show_viewer'] === false &&
                     settings['large_image.auto_set'] === false &&
-                    settings['large_image.default_viewer'] === 'geojs');
+                    settings['large_image.default_viewer'] === 'geojs' &&
+                    settings['large_image.max_thumbnail_files'] === 5);
         }, 'large_image settings to change');
         girderTest.waitForLoad();
     });

--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -21,6 +21,7 @@ import json
 import math
 import os
 import requests
+import six
 import struct
 import time
 from six.moves import range
@@ -529,13 +530,10 @@ class LargeImageTilesTest(base.TestCase):
         self._testTilesZXY(itemId, tileMetadata, params, PNGHeader)
 
         # Check that invalid encodings are rejected
-        try:
+        with six.assertRaisesRegex(self, Exception, 'Invalid encoding'):
             resp = self.request(path='/item/%s/tiles' % itemId,
                                 user=self.admin,
                                 params={'encoding': 'invalid'})
-            self.assertTrue(False)
-        except AssertionError as exc:
-            self.assertIn('Invalid encoding', exc.args[0])
 
         # Check that JPEG options are honored.
         resp = self.request(path='/item/%s/tiles/zxy/0/0/0' % itemId,
@@ -859,21 +857,17 @@ class LargeImageTilesTest(base.TestCase):
             self.assertFalse(self.model('setting').get(key))
             self.model('setting').set(key, 'true')
             self.assertTrue(self.model('setting').get(key))
-            try:
+            with six.assertRaisesRegex(self, ValidationException,
+                                       'must be a boolean'):
                 self.model('setting').set(key, 'not valid')
-                self.assertTrue(False)
-            except ValidationException as exc:
-                self.assertIn('must be a boolean', exc.args[0])
         self.model('setting').set(
             constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER, 'geojs')
         self.assertEqual(self.model('setting').get(
             constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER), 'geojs')
-        try:
+        with six.assertRaisesRegex(self, ValidationException,
+                                   'must be a non-negative integer'):
             self.model('setting').set(
                 constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES, -1)
-            self.assertTrue(False)
-        except ValidationException as exc:
-            self.assertIn('must be a non-negatuve integer', exc.args[0])
         self.model('setting').set(
             constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES, 5)
         self.assertEqual(self.model('setting').get(

--- a/server/base.py
+++ b/server/base.py
@@ -50,6 +50,11 @@ def _postUpload(event):
         Item.save(item)
 
 
+def removeThumbnails(event):
+    ModelImporter.model('image_item', 'large_image').removeThumbnailFiles(
+        event.info)
+
+
 def validateSettings(event):
     key, val = event.info['key'], event.info['value']
 
@@ -90,3 +95,4 @@ def load(info):
     events.bind('model.group.save.after', 'large_image',
                 invalidateLoadModelCache)
     events.bind('model.item.remove', 'large_image', invalidateLoadModelCache)
+    events.bind('model.item.remove', 'large_image', removeThumbnails)

--- a/server/base.py
+++ b/server/base.py
@@ -18,8 +18,9 @@
 ###############################################################################
 
 from girder import events, plugin, logger
-from girder.constants import AccessType
-from girder.utility.model_importer import ModelImporter
+from girder.constants import AccessType, SettingDefault
+from girder.utility import setting_utilities
+from girder.models.model_base import ModelImporter, ValidationException
 
 from . import constants
 from .loadmodelcache import invalidateLoadModelCache
@@ -62,7 +63,7 @@ def checkForLargeImageFiles(event):
     if not file.get('itemId') or not possible:
         return
     if not ModelImporter.model('setting').get(
-            constants.PluginSettings.LARGE_IMAGE_AUTO_SET, True):
+            constants.PluginSettings.LARGE_IMAGE_AUTO_SET):
         return
     item = ModelImporter.model('item').load(
         file['itemId'], force=True, exc=False)
@@ -82,22 +83,55 @@ def removeThumbnails(event):
         event.info)
 
 
-def validateSettings(event):
-    key, val = event.info['key'], event.info['value']
+# Validators
 
-    if key in (constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS,
-               constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER,
-               constants.PluginSettings.LARGE_IMAGE_AUTO_SET):
-        if str(val).lower() not in ('false', 'true', ''):
-            return
-        val = (str(val).lower() != 'false')
-    elif key == constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER:
-        val = str(val).strip()
-    else:
-        return
-    event.info['value'] = val
-    event.preventDefault().stopPropagation()
+@setting_utilities.validator({
+    constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS,
+    constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER,
+    constants.PluginSettings.LARGE_IMAGE_AUTO_SET,
+})
+def validateBoolean(doc):
+    val = doc['value']
+    if str(val).lower() not in ('false', 'true', ''):
+        raise ValidationException('%s must be a boolean.' % doc['key'], 'value')
+    doc['value'] = (str(val).lower() != 'false')
 
+
+@setting_utilities.validator({
+    constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES,
+})
+def validateNonnegativeInteger(doc):
+    val = doc['value']
+    try:
+        val = int(val)
+        if val < 0:
+            raise ValueError
+    except ValueError:
+        raise ValidationException('%s must be a non-negatuve integer.' % (
+            doc['key'], ), 'value')
+    doc['value'] = val
+
+
+@setting_utilities.validator({
+    constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER
+})
+def validateDefaultViewer(doc):
+    doc['value'] = str(doc['value']).strip()
+
+
+# Defaults
+
+# Defaults that have fixed values can just be added to the system defaults
+# dictionary.
+SettingDefault.defaults.update({
+    constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS: True,
+    constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER: True,
+    constants.PluginSettings.LARGE_IMAGE_AUTO_SET: True,
+    constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES: 10,
+})
+
+
+# Configuration and load
 
 @plugin.config(
     name='Large image',
@@ -117,7 +151,6 @@ def load(info):
     ModelImporter.model('annotation', plugin='large_image')
 
     events.bind('data.process', 'large_image', _postUpload)
-    events.bind('model.setting.validate', 'large_image', validateSettings)
     events.bind('model.folder.save.after', 'large_image',
                 invalidateLoadModelCache)
     events.bind('model.group.save.after', 'large_image',

--- a/server/base.py
+++ b/server/base.py
@@ -145,7 +145,7 @@ def validateNonnegativeInteger(doc):
         if val < 0:
             raise ValueError
     except ValueError:
-        raise ValidationException('%s must be a non-negatuve integer.' % (
+        raise ValidationException('%s must be a non-negative integer.' % (
             doc['key'], ), 'value')
     doc['value'] = val
 

--- a/server/constants.py
+++ b/server/constants.py
@@ -24,3 +24,4 @@ class PluginSettings:
     LARGE_IMAGE_SHOW_VIEWER = 'large_image.show_viewer'
     LARGE_IMAGE_DEFAULT_VIEWER = 'large_image.default_viewer'
     LARGE_IMAGE_AUTO_SET = 'large_image.auto_set'
+    LARGE_IMAGE_MAX_THUMBNAIL_FILES = 'large_image.max_thumbnail_files'

--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -295,8 +295,7 @@ class ImageItem(Item):
         # Return the data
         return thumbData, thumbMime
 
-    def removeThumbnailFiles(self, item, keep=0,
-                             sort=[('_id', SortDir.DESCENDING)], **kwargs):
+    def removeThumbnailFiles(self, item, keep=0, sort=None, **kwargs):
         """
         Remove all large image thumbnails from an item.
 
@@ -309,6 +308,8 @@ class ImageItem(Item):
         :returns: a tuple of (the number of files before removal, the number of
             files removed).
         """
+        if not sort:
+            sort = [('_id', SortDir.DESCENDING)]
         fileModel = self.model('file')
         query = {
             'attachedToType': 'item',

--- a/server/rest/tiles.py
+++ b/server/rest/tiles.py
@@ -366,5 +366,6 @@ class TilesItemResource(Item):
             constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER,
             constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER,
             constants.PluginSettings.LARGE_IMAGE_AUTO_SET,
+            constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES,
         ]
         return {k: self.model('setting').get(k) for k in keys}

--- a/server/rest/tiles.py
+++ b/server/rest/tiles.py
@@ -264,12 +264,14 @@ class TilesItemResource(Item):
             ('encoding', str),
         ])
         try:
-            thumbData, thumbMime = self.imageItemModel.getThumbnail(
-                item, **params)
+            result = self.imageItemModel.getThumbnail(item, **params)
         except TileGeneralException as e:
             raise RestException(e.message)
         except ValueError as e:
             raise RestException('Value Error: %s' % e.message)
+        if not isinstance(result, tuple):
+            return result
+        thumbData, thumbMime = result
         cherrypy.response.headers['Content-Type'] = thumbMime
         setRawResponse()
         return thumbData

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -214,7 +214,7 @@ class TileSource(object):
     def getTileMimeType(self):
         return 'image/jpeg'
 
-    def getThumbnail(self, width=None, height=None, **kwargs):
+    def getThumbnail(self, width=None, height=None, levelZero=False, **kwargs):
         """
         Get a basic thumbnail from the current tile source.  Aspect ratio is
         preserved.  If neither width nor height is given, a default value is
@@ -223,6 +223,8 @@ class TileSource(object):
 
         :param width: maximum width in pixels.
         :param height: maximum height in pixels.
+        :param levelZero: if true, always use the level zero tile.  Otherwise,
+            the thumbnail is generated so that it is never upsampled.
         :param **kwargs: optional arguments.  Some options are encoding,
             jpegQuality, and jpegSubsampling.
         :returns: thumbData, thumbMime: the image data and the mime type.
@@ -236,8 +238,7 @@ class TileSource(object):
         # alwaysUseLevelZero is True, then the the thumbnail is generated more
         # swiftly, but may look poor.  We may want to add a parameter for this
         # option, or only use the high-quality results.
-        alwaysUseLevelZero = False
-        if not alwaysUseLevelZero:
+        if not levelZero:
             params = dict(kwargs)
             for key in ('left', 'top', 'right', 'bottom', 'regionWidth',
                         'regionHeight'):

--- a/web_client/js/configView.js
+++ b/web_client/js/configView.js
@@ -18,6 +18,9 @@ girder.views.largeImageConfig = girder.View.extend({
             }, {
                 key: 'large_image.auto_set',
                 value: this.$('.g-large-image-auto-set-on').prop('checked')
+            }, {
+                key: 'large_image.max_thumbnail_files',
+                value: this.$('.g-large-image-max-thumbnail-files').val() - 0
             }]);
         }
     },

--- a/web_client/templates/largeImageConfig.jade
+++ b/web_client/templates/largeImageConfig.jade
@@ -38,5 +38,13 @@ form#g-large-image-form(role="form")
       label.radio-inline
         input.g-large-image-auto-set-off(type="radio" name="g-large-image-auto-set" checked=(settings['large_image.auto_set'] !== false ? undefined : 'checked'))
         | No automatic use
+  .form-group
+    label
+      | Maximum number of thumbnail files to save per item
+    p.g-large-image-description
+      | Caching files speeds up thumbnail retrieval but takes some storage space.  Use 0 to not cache thumbnails as files.
+    input.input-sm.form-control.g-large-image-max-thumbnail-files(
+      type="text", value="#{settings['large_image.max_thumbnail_files']}",
+      placeholder="Use 0 to not cache thumbnails as files.")
   p#g-large-image-error-message.g-validation-failed-message
   input.btn.btn-sm.btn-primary(type="submit", value="Save")


### PR DESCRIPTION
There is a configurable cap on the number of files stored.

We will want to add something to automatically thumbnails as a background job (as a separate PR) when new large images are added.