### PR TITLE
Add an example to show using large_image.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,12 @@
 Large Image |build-status| |license-badge|
 ==========================================
+
 As a Girder_ Plugin
 -------------------
 
-A Girder plugin to create, serve, and display large multiresolution images. 
+A Girder plugin to create, serve, and display large multiresolution images.
+
+Upload image files to Girder.  If they are not already in a tiled-format, they can be converted to tiled images.  The plugin has a variety of viewers to examine the images.
 
 
 As a stand-alone Python module
@@ -11,6 +14,37 @@ As a stand-alone Python module
 
 A Python module to work with large multiresolution images.
 
+Installation
+++++++++++++
+
+1.  `Install OpenSlide <http://openslide.org/download/>`_
+
+    If you are install on Ubuntu 14.04, there is a known bug in OpenJPEG that will prevent OpenSlide from reading certain files.  This requires building OpenJPEG, libtiff, and OpenSlide from source to work around the problem.
+
+    You may want to install optional utilities:
+
+    * memcached - this allows memcached to be used for caching
+
+2.  pip install --user numpy==1.10.2
+
+    The python libtiff library fails to include numpy as a dependency, which means that it must be installed manually before you can install large_image.
+
+    You may want to pip install optional modules:
+
+    * psutil - this helps determine how much memory is available for caching
+
+3.  git clone https://github.com/DigitalSlideArchive/large_image.git
+
+4.  cd large_image
+
+5.  python setup.py install --user
+
+Examples
+++++++++
+
+*   `Finding the average color of an image <examples/average_color.py>`_
+
+    This opens a tiled image and computes the average color at a specified magnification.
 
 
 .. _Girder: https://github.com/girder/girder
@@ -22,4 +56,3 @@ A Python module to work with large multiresolution images.
 .. |license-badge| image:: https://raw.githubusercontent.com/girder/girder/master/docs/license.png
     :target: https://pypi.python.org/pypi/girder
     :alt: License
-

--- a/examples/average_color.py
+++ b/examples/average_color.py
@@ -1,0 +1,54 @@
+# An example to get a tile source, save a thumbnail, and iterate through the
+# tiles at a specific magnification, reporting the average color of each tile.
+
+import argparse
+import numpy
+
+import large_image
+
+
+def average_color(imagePath, magnification=None):
+    """
+    Print the average color for a tiled image file.
+
+    :param imagePath: path of the file to analyze.
+    :param magnification: optional magnification to use for the analysis.
+    """
+    source = large_image.getTileSource(imagePath)
+    # get a thumbnail no larger than 1024x1024 pixels
+    thumbnail, mimeType = source.getThumbnail(
+        width=1024, height=1024, encoding='JPEG')
+    print('Made a thumbnail of type %s taking %d bytes' % (
+        mimeType, len(thumbnail)))
+    # We could save it, if we want to.
+    # open('/tmp/thumbnail.jpg', 'wb').write(thumbnail)
+
+    tileMeans = []
+    tileWeights = []
+    # iterate through the tiles at a particular magnification:
+    for tile in source.tileIterator(
+            format=large_image.tilesource.TILE_FORMAT_NUMPY,
+            scale={'magnification': magnification},
+            resample=True):
+        # The tile image data is in tile['tile'] and is a numpy
+        # multi-dimensional array
+        mean = numpy.mean(tile['tile'], axis=(0, 1))
+        tileMeans.append(mean)
+        tileWeights.append(tile['width'] * tile['height'])
+        print('x: %d  y: %d  w: %d  h: %d  mag: %g  color: %g %g %g' % (
+            tile['x'], tile['y'], tile['width'], tile['height'],
+            tile['magnification'], mean[0], mean[1], mean[2]))
+    mean = numpy.average(tileMeans, axis=0, weights=tileWeights)
+    print('Average color: %g %g %g' % (mean[0], mean[1], mean[2]))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Compute the mean color of a tiled image')
+    parser.add_argument('path', metavar='image-path', type=str,
+                        help='Path of the tiled image to examine')
+    parser.add_argument('-m', '--maginfication', dest='magnfication',
+                        type=float,
+                        help='Magnification to use to examine the image')
+    args = parser.parse_args()
+    average_color(args.path, args.magnfication)

--- a/large_image/__init__.py
+++ b/large_image/__init__.py
@@ -23,4 +23,4 @@ from server import cache_util
 
 getTileSource = tilesource.getTileSource  # noqa
 
-__all__ = [server, tilesource, getTileSource, cache_util]
+__all__ = ['server', 'tilesource', 'getTileSource', 'cache_util']

--- a/plugin.cmake
+++ b/plugin.cmake
@@ -69,9 +69,12 @@ set_property(TEST server_large_image.cached_tiles.PythonCache APPEND PROPERTY
   "LARGE_IMAGE_CACHE_BACKEND=python"
   "LARGE_IMAGE_DATA=${PROJECT_BINARY_DIR}/data/plugins/large_image")
 
-add_python_test(sources PLUGIN large_image BIND_SERVER EXTERNAL_DATA
-  "plugins/large_image/sample_image.ptif"
-  "plugins/large_image/sample_jp2k_33003_TCGA-CV-7242-11A-01-TS1.1838afb1-9eee-4a70-9ae3-50e3ab45e242.svs"
+add_python_test(sources PLUGIN large_image BIND_SERVER 
+  # There is a bug in cmake that fails when external data files are added to
+  # multiple tests, so comment out the external data directive.
+  # EXTERNAL_DATA
+  # "plugins/large_image/sample_image.ptif"
+  # "plugins/large_image/sample_jp2k_33003_TCGA-CV-7242-11A-01-TS1.1838afb1-9eee-4a70-9ae3-50e3ab45e242.svs"
   )
 set_property(TEST server_large_image.sources APPEND PROPERTY ENVIRONMENT
   "LARGE_IMAGE_DATA=${PROJECT_BINARY_DIR}/data/plugins/large_image")
@@ -79,13 +82,23 @@ set_property(TEST server_large_image.sources APPEND PROPERTY ENVIRONMENT
 
 add_python_test(import PLUGIN large_image BIND_SERVER)
 
-add_python_test(girderless PLUGIN large_image EXTERNAL_DATA
-  # There is a bug in cmake that fails when an external data file is added to
-  # three separate tests, so comment out the file.
+add_python_test(girderless PLUGIN large_image 
+  # There is a bug in cmake that fails when external data files are added to
+  # multiple tests, so comment out the external data directive.
+  # EXTERNAL_DATA
   # "plugins/large_image/sample_image.ptif"
-  "plugins/large_image/sample_svs_image.TCGA-DU-6399-01A-01-TS1.e8eb65de-d63e-42db-af6f-14fefbbdf7bd.svs"
+  # "plugins/large_image/sample_svs_image.TCGA-DU-6399-01A-01-TS1.e8eb65de-d63e-42db-af6f-14fefbbdf7bd.svs"
   )
 set_property(TEST server_large_image.girderless APPEND PROPERTY ENVIRONMENT
+  "LARGE_IMAGE_DATA=${PROJECT_BINARY_DIR}/data/plugins/large_image")
+
+add_python_test(examples PLUGIN large_image 
+  # There is a bug in cmake that fails when external data files are added to
+  # multiple tests, so comment out the external data directive.
+  # EXTERNAL_DATA
+  # "plugins/large_image/sample_image.ptif"
+  )
+set_property(TEST server_large_image.examples APPEND PROPERTY ENVIRONMENT
   "LARGE_IMAGE_DATA=${PROJECT_BINARY_DIR}/data/plugins/large_image")
 
 add_web_client_test(

--- a/plugin_tests/examples_test.py
+++ b/plugin_tests/examples_test.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+##############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+##############################################################################
+
+import os
+import subprocess
+import unittest
+
+
+class LargeImageExamplesTest(unittest.TestCase):
+    def testAverageColor(self):
+        # Test running the program
+        testDir = os.path.dirname(os.path.realpath(__file__))
+        examplesDir = os.path.join(testDir, '../examples')
+
+        prog = 'average_color.py'
+        imagePath = os.path.join(os.environ['LARGE_IMAGE_DATA'],
+                                 'sample_image.ptif')
+        process = subprocess.Popen(
+            ['python', prog, imagePath, '-m', '1.25'],
+            shell=False, stdout=subprocess.PIPE, cwd=examplesDir)
+        results = process.stdout.readlines()
+        self.assertEqual(len(results), 19)
+        finalColor = [float(val) for val in results[-1].split()[-3:]]
+        self.assertEqual(round(finalColor[0]), 245)
+        self.assertEqual(round(finalColor[1]), 247)
+        self.assertEqual(round(finalColor[2]), 247)

--- a/plugin_tests/girderless_test.py
+++ b/plugin_tests/girderless_test.py
@@ -19,14 +19,13 @@
 
 import math
 import os
-
-from tests import base
+import unittest
 
 JPEGHeader = '\xff\xd8\xff'
 PNGHeader = '\x89PNG'
 
 
-class LargeImageGirderlessTest(base.TestCase):
+class LargeImageGirderlessTest(unittest.TestCase):
     def _testTilesZXY(self, source, metadata, tileParams={},
                       imgHeader=JPEGHeader):
         """
@@ -83,10 +82,6 @@ class LargeImageGirderlessTest(base.TestCase):
         except tilesource.TileSourceException:
             image = None
         self.assertIsNone(image)
-
-    def setUp(*args, **kwargs):
-        # Avoid starting girder
-        pass
 
     def testWithoutGirder(self):
         from large_image import tilesource

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     packages=[
         'large_image',
         'large_image.server',
+        'large_image.server.cache_util',
         'large_image.server.models',
         'large_image.server.rest',
         'large_image.server.tilesource',


### PR DESCRIPTION
Show the example as part of the README.  Test the example.

Add a missing module to setup.py.

This has basic information on how to install large_image as a python module (issue #79).