### PR TITLE
Don't require memcache. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,8 @@ before_install:
 
 install:
   - cd $girder_path
-  - pip install --no-cache-dir -U -r requirements.txt -r requirements-dev.txt -r $main_path/requirements.txt -e .
+  - pip install --no-cache-dir -U -r requirements.txt -r requirements-dev.txt -e .
+  - pip install -r $main_path/requirements.txt -e .
   - python -c "import openslide;print openslide.__version__"
   - npm install
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,17 @@
-cachetools==1.1.6
-enum34==1.1.6
-jsonschema==2.5.1
-psutil==4.2.0
-pylibmc==1.5.1
-six==1.10.0
+cachetools>=1.1.6
+enum34>=1.1.6
+jsonschema>=2.5.1
+psutil>=4.2.0
+pylibmc>=1.5.1
+six>=1.10.0
 
 # Pillow is already required by another Girder plugin, but include it since we
 # can be installed by setup.py
-Pillow==3.2.0
+Pillow>=3.2.0
 
 # https://github.com/DigitalSlideArchive/large_image/issues/30
-numpy==1.10.2
+numpy>=1.10.2
 
-libtiff==0.4.0
+libtiff>=0.4.0
 
 openslide-python>=1.1.0

--- a/server/cache_util/__init__.py
+++ b/server/cache_util/__init__.py
@@ -17,12 +17,15 @@
 #  limitations under the License.
 ###############################################################################
 
-from .cache import LruCacheMetaclass,  tileCache, tileLock
-from .memcache import MemCache, strhash
+from .cache import LruCacheMetaclass, tileCache, tileLock, strhash
+try:
+    from .memcache import MemCache
+except ImportError:
+    MemCache = None
 from .cachefactory import CacheFactory, pickAvailableCache
 from cachetools import cached, Cache, LRUCache
 
 
-# flake8: noqa
-__all__ = (CacheFactory, tileCache, tileLock, MemCache, strhash,
-           LruCacheMetaclass, pickAvailableCache, cached, Cache, LRUCache)
+__all__ = ('CacheFactory', 'tileCache', 'tileLock', 'MemCache', 'strhash',
+           'LruCacheMetaclass', 'pickAvailableCache', 'cached', 'Cache',
+           'LRUCache')

--- a/server/cache_util/cache.py
+++ b/server/cache_util/cache.py
@@ -20,9 +20,12 @@
 
 import six
 
-from .memcache import strhash
-from cachetools import LRUCache, Cache
+from cachetools import LRUCache, Cache, hashkey
 from .cachefactory import CacheFactory
+
+
+def strhash(*args, **kwargs):
+    return str(hashkey(*args, **kwargs))
 
 
 def defaultCacheKeyFunc(args, kwargs):

--- a/server/cache_util/cachefactory.py
+++ b/server/cache_util/cachefactory.py
@@ -65,7 +65,8 @@ class CacheFactory():
             curConfig = config.getConfig().get('large_image', defaultConfig)
         else:
             curConfig = defaultConfig
-        cacheBackend = curConfig.get('cache_backend')
+        # memcached is the fallback default, if available.
+        cacheBackend = curConfig.get('cache_backend', 'memcached')
         if cacheBackend:
             cacheBackend = str(cacheBackend).lower()
         if cacheBackend == 'memcached' and MemCache:

--- a/server/cache_util/cachefactory.py
+++ b/server/cache_util/cachefactory.py
@@ -28,7 +28,10 @@ except ImportError:
     import logging as logprint
     config = None
 
-from .memcache import MemCache
+try:
+    from .memcache import MemCache
+except ImportError:
+    MemCache = None
 from cachetools import LRUCache
 
 try:
@@ -65,7 +68,7 @@ class CacheFactory():
         cacheBackend = curConfig.get('cache_backend')
         if cacheBackend:
             cacheBackend = str(cacheBackend).lower()
-        if cacheBackend == 'memcached':
+        if cacheBackend == 'memcached' and MemCache:
             # lock needed because pylibmc(memcached client) is not threadsafe
             tileCacheLock = threading.Lock()
 

--- a/server/cache_util/memcache.py
+++ b/server/cache_util/memcache.py
@@ -17,7 +17,7 @@
 #  limitations under the License.
 #############################################################################
 
-from cachetools import Cache, hashkey
+from cachetools import Cache
 import pylibmc
 import hashlib
 
@@ -25,10 +25,6 @@ try:
     from girder import logprint
 except ImportError:
     import logging as logprint
-
-
-def strhash(*args, **kwargs):
-    return str(hashkey(*args, **kwargs))
 
 
 class MemCache(Cache):

--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -233,7 +233,7 @@ class ImageItem(Item):
 
             del item['largeImage']
 
-            self.save(item)
+            item = self.save(item)
             deleted = True
         self.removeThumbnailFiles(item)
         return deleted

--- a/server/rest/tiles.py
+++ b/server/rest/tiles.py
@@ -23,7 +23,7 @@ from girder.api import access, filter_logging
 from girder.api.v1.item import Item
 from girder.api.describe import describeRoute, Description
 from girder.api.rest import filtermodel, loadmodel, RestException, \
-    setRawResponse
+    setRawResponse, setResponseHeader
 from girder.models.model_base import AccessType
 
 from ..models import TileGeneralException
@@ -204,7 +204,7 @@ class TilesItemResource(Item):
                 item, x, y, z, **imageArgs)
         except TileGeneralException as e:
             raise RestException(e.message, code=404)
-        cherrypy.response.headers['Content-Type'] = tileMime
+        setResponseHeader('Content-Type', tileMime)
         setRawResponse()
         return tileData
 
@@ -234,8 +234,8 @@ class TilesItemResource(Item):
             self, 'item', id=itemId, allowCookie=True, level=AccessType.READ)
         # Explicitly set a expires time to encourage browsers to cache this for
         # a while.
-        cherrypy.response.headers['Expires'] = cherrypy.lib.httputil.HTTPDate(
-            cherrypy.serving.response.time + 600)
+        setResponseHeader('Expires', cherrypy.lib.httputil.HTTPDate(
+            cherrypy.serving.response.time + 600))
         return self._getTile(item, z, x, y, params)
 
     @describeRoute(
@@ -306,7 +306,7 @@ class TilesItemResource(Item):
         if not isinstance(result, tuple):
             return result
         thumbData, thumbMime = result
-        cherrypy.response.headers['Content-Type'] = thumbMime
+        setResponseHeader('Content-Type', thumbMime)
         setRawResponse()
         return thumbData
 
@@ -402,7 +402,7 @@ class TilesItemResource(Item):
             raise RestException(e.message)
         except ValueError as e:
             raise RestException('Value Error: %s' % e.message)
-        cherrypy.response.headers['Content-Type'] = regionMime
+        setResponseHeader('Content-Type', regionMime)
         setRawResponse()
         return regionData
 

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 
 import json
 import pkg_resources
+import sys
 
 try:
     from setuptools import setup
@@ -23,7 +24,11 @@ try:
         ireqs = pkg_resources.parse_requirements(f.read())
 except pkg_resources.RequirementParseError:
     raise
+# Don't include pylibmc for Windows
+if 'win' in sys.platform:
+    ireqs = [req for req in ireqs if req.key not in ('pylibmc', )]
 requirements = [str(req) for req in ireqs]
+
 
 test_requirements = [
     # TODO: Should we list Girder here?


### PR DESCRIPTION
This should allow easier deployment to Windows.

This doesn't install pylibmc on Windows (if it happens to be installed, it will be used).

This changes requirements to >= instead of ==, which reduces install thrashing.

Assuming that you've installed OpenSlide and libtiff on Windows, examples/average_color.py now works on Windows.