### PR TITLE
Add guards against memcached failures.

### DIFF
--- a/server/cache_util/memcache.py
+++ b/server/cache_util/memcache.py
@@ -47,7 +47,7 @@ class MemCache(cachetools.Cache):
             'dead_timeout': 10,
         }
         # Adding remove_failed prevents recovering in a single memcached server
-        # instance, so onlydo it if there are multiple servers
+        # instance, so only do it if there are multiple servers
         if len(url) > 1:
             behaviors['remove_failed'] = 1
         # name mangling to override 'private variable' __data in cache


### PR DESCRIPTION
If memcached had the wrong server address, it would fail.  Now, log the error (throttled) and don't use the cache.  Improve the retry options for the memcached client.  Add a test for the failure conditions.

Allow specifying a list of memcached servers in the config file.