### PR TITLE
Shift an info message to a debug message so the logs don't contain needless warnings.

### DIFF
--- a/plugin_tests/common.py
+++ b/plugin_tests/common.py
@@ -235,7 +235,7 @@ class LargeImageCommonTest(base.TestCase):
                 self.assertStatusOk(resp)
                 break
             except AssertionError as exc:
-                if 'File must have at least 1 level' in exc.args[0]:
+                if 'didn\'t meet requirements' in exc.args[0]:
                     return False
                 if 'No large image file' in exc.args[0]:
                     return None

--- a/server/tilesource/tiff.py
+++ b/server/tilesource/tiff.py
@@ -73,9 +73,10 @@ class TiffFileTileSource(FileTileSource):
                 self._tiffDirectories.append(tiffDirectory)
 
         if not self._tiffDirectories:
-            logger.info('File %s didn\'t meet requirements for tile source: '
-                        '%s' % (largeImagePath, lastException))
-            raise TileSourceException('File must have at least 1 level')
+            msg = 'File %s didn\'t meet requirements for tile source: %s' % (
+                largeImagePath, lastException)
+            logger.debug(msg)
+            raise TileSourceException(msg)
 
         # Multiresolution TIFFs are stored with full-resolution layer in
         #   directory 0


### PR DESCRIPTION
Before, some file that could be read as svs files would log a warning when the tif reader reported that it wouldn't handle them.