### PR TITLE
Attach thumbnail files during the upload process.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ services:
 before_install:
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then export PY3="true"; else export PY2="true"; fi
   - if [ -n "${PY3}" ]; then export MONGO_VERSION=3.0.7; export PY_COVG="OFF"; else export MONGO_VERSION=2.6.11; export PY_COVG="ON"; export DEPLOY=true; fi
-  - GIRDER_VERSION=cb846cee604b07368800e99322c7347039a2a464
+  - GIRDER_VERSION=60a74fbe8c79392c9908b6f506e9722e9e77caab
   - GIRDER_WORKER_VERSION=2cfb739c096c2373f8bbe00853e3709f433192a6
   - main_path=$PWD
   - build_path=$PWD/build

--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -280,11 +280,9 @@ class ImageItem(Item):
             # Save the thumbnail as a file
             thumbfile = self.model('upload').uploadFromFile(
                 six.BytesIO(thumbData), size=len(thumbData),
-                name='_largeImageThumbnail', parentType=None, parent=None,
-                user=None, mimeType=thumbMime)
+                name='_largeImageThumbnail', parentType='item', parent=item,
+                user=None, mimeType=thumbMime, attachParent=True)
             thumbfile.update({
-                'attachedToType': 'item',
-                'attachedToId': item['_id'],
                 'isLargeImageThumbnail': True,
                 'thumbnailKey': key,
             })


### PR DESCRIPTION
This fixes a bug that occurs with the provenance plugin (see Girder PR #1591).