### PR TITLE
Limit the number of simultaneous thumbnails that are requested in the itemList.

### DIFF
--- a/web_client/js/itemList.js
+++ b/web_client/js/itemList.js
@@ -15,14 +15,14 @@ girder.wrap(girder.views.ItemListWidget, 'render', function (render) {
      *      thumbnails are located.
      */
     function _loadMoreImages(parent) {
-        var loading = $('.large_image_thumbnail img.loading', parent).length;
-        if (maxSimultaneous > loading) {
-          $('.large_image_thumbnail img.waiting', parent).slice(0, maxSimultaneous - loading).each(function () {
-            var img = $(this);
-            img.removeClass('waiting').addClass('loading');
-            img.attr('src', img.attr('deferred-src'));
-          });
-        }
+      var loading = $('.large_image_thumbnail img.loading', parent).length;
+      if (maxSimultaneous > loading) {
+        $('.large_image_thumbnail img.waiting', parent).slice(0, maxSimultaneous - loading).each(function () {
+          var img = $(this);
+          img.removeClass('waiting').addClass('loading');
+          img.attr('src', img.attr('deferred-src'));
+        });
+      }
     }
 
     render.call(this);

--- a/web_client/js/itemList.js
+++ b/web_client/js/itemList.js
@@ -1,4 +1,30 @@
 girder.wrap(girder.views.ItemListWidget, 'render', function (render) {
+    /* Chrome limits the number of connections to a single domain, which means
+     * that time-consuming requests for thumbnails can bind-up the web browser.
+     * To avoid this, limit the maximum number of thumbnails that are requested
+     * at a time.  At this time (2016-09-27), Chrome's limit is 6 connections;
+     * to preserve some overhead, use a number a few lower than that. */
+    var maxSimultaneous = 3;
+
+    /**
+     * When we might need to load another image, check how many are waiting or
+     * currently being loaded, and ask an appropriate additional number to
+     * load.
+     *
+     * @param {jquery element} parent parent under which the large_image
+     *      thumbnails are located.
+     */
+    function _loadMoreImages(parent) {
+        var loading = $('.large_image_thumbnail img.loading', parent).length;
+        if (maxSimultaneous > loading) {
+          $('.large_image_thumbnail img.waiting', parent).slice(0, maxSimultaneous - loading).each(function () {
+            var img = $(this);
+            img.removeClass('waiting').addClass('loading');
+            img.attr('src', img.attr('deferred-src'));
+          });
+        }
+    }
+
     render.call(this);
     girder.views.largeImageConfig.getSettings(_.bind(function (settings) {
         if (settings['large_image.show_thumbnails'] === false ||
@@ -14,15 +40,25 @@ girder.wrap(girder.views.ItemListWidget, 'render', function (render) {
             $.each(items, function (idx, item) {
                 var elem = $('<div class="large_image_thumbnail"/>');
                 if (item.get('largeImage')) {
-                    elem.append($('<img/>').attr(
-                            'src', girder.apiRoot + '/item/' + item.id +
-                            '/tiles/thumbnail?width=160&height=100'));
+                    /* We store the desired src attribute in deferred-src until
+                     * we actually load the image. */
+                    elem.append($('<img class="waiting"/>').attr(
+                            'deferred-src', girder.apiRoot + '/item/' +
+                            item.id + '/tiles/thumbnail?width=160&height=100'));
                     $('img', elem).one('error', function () {
                         $('img', elem).addClass('failed-to-load');
+                        $('img', elem).removeClass('loading waiting');
+                        _loadMoreImages(parent);
+                    });
+                    $('img', elem).one('load', function () {
+                        $('img', elem).addClass('loaded');
+                        $('img', elem).removeClass('loading waiting');
+                        _loadMoreImages(parent);
                     });
                 }
                 $('a[g-item-cid="' + item.cid + '"]>i', parent).before(elem);
             });
+            _loadMoreImages(parent);
         }
         return this;
     }, this));

--- a/web_client/js/itemList.js
+++ b/web_client/js/itemList.js
@@ -15,14 +15,14 @@ girder.wrap(girder.views.ItemListWidget, 'render', function (render) {
      *      thumbnails are located.
      */
     function _loadMoreImages(parent) {
-      var loading = $('.large_image_thumbnail img.loading', parent).length;
-      if (maxSimultaneous > loading) {
-        $('.large_image_thumbnail img.waiting', parent).slice(0, maxSimultaneous - loading).each(function () {
-          var img = $(this);
-          img.removeClass('waiting').addClass('loading');
-          img.attr('src', img.attr('deferred-src'));
-        });
-      }
+        var loading = $('.large_image_thumbnail img.loading', parent).length;
+        if (maxSimultaneous > loading) {
+            $('.large_image_thumbnail img.waiting', parent).slice(0, maxSimultaneous - loading).each(function () {
+                var img = $(this);
+                img.removeClass('waiting').addClass('loading');
+                img.attr('src', img.attr('deferred-src'));
+            });
+        }
     }
 
     render.call(this);

--- a/web_client/stylesheets/itemList.styl
+++ b/web_client/stylesheets/itemList.styl
@@ -2,7 +2,7 @@ div.large_image_thumbnail
   display inline-block
   width 160px
   img
-    display block
+    display none
     margin auto
-    &.failed-to-load
-      display none
+    &.loaded
+      display block


### PR DESCRIPTION
Chrome limits the maximum connectors to a domain to 6.  Girder uses one for getting events, leaving five.  This uses no more than 3 for thumbnails, which leaves some overhead for navigation.  If you navigate between item lists quickly, the connections can still be saturated, as Chrome doesn't cancel the image requests.  We would have to load the image to a hidden element first, and then load it to the visible element to work around that, so that the hidden elements don't vanish on page transitions.

This resolves issue #89.