### PR TITLE
Restrict cachetools to a version <2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cachetools>=1.1.6
+cachetools>=1.1.6,<2.0.0
 enum34>=1.1.6
 jsonschema>=2.5.1
 psutil>=4.2.0


### PR DESCRIPTION
Restricting cachetools to a version <2.0.0 to resolve the error `ImportError: cannot import name hashkey` while importing or loading the large_image as a girder plugin.

See this [comment](https://github.com/DigitalSlideArchive/HistomicsTK/pull/209#issuecomment-251398686) for more details.

