### PR TITLE
Add edge options for tiles.

### DIFF
--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -355,6 +355,37 @@ class LargeImageTilesTest(common.LargeImageCommonTest):
         self.assertEqual(image[:len(common.JPEGHeader)], common.JPEGHeader)
         self.assertTrue(len(image) < defaultLength)
 
+        # Test that edge options are honored
+        resp = self.request(path='/item/%s/tiles/zxy/0/0/0' % itemId,
+                            user=self.admin, isJson=False,
+                            params={'encoding': 'PNG', 'edge': 'crop'})
+        self.assertStatusOk(resp)
+        image = self.getBody(resp, text=False)
+        self.assertEqual(image[:len(common.PNGHeader)], common.PNGHeader)
+        (width, height) = struct.unpack('!LL', image[16:24])
+        self.assertEqual(width, 124)
+        self.assertEqual(height, 54)
+        with six.assertRaisesRegex(self, Exception, 'unknown color specifier'):
+            self.request(path='/item/%s/tiles/zxy/0/0/0' % itemId,
+                         user=self.admin, isJson=False,
+                         params={'edge': 'not_a_color'})
+        resp = self.request(path='/item/%s/tiles/zxy/0/0/0' % itemId,
+                            user=self.admin, isJson=False,
+                            params={'encoding': 'PNG', 'edge': '#DDD'})
+        self.assertStatusOk(resp)
+        greyImage = self.getBody(resp, text=False)
+        self.assertEqual(greyImage[:len(common.PNGHeader)], common.PNGHeader)
+        (width, height) = struct.unpack('!LL', greyImage[16:24])
+        self.assertEqual(width, 240)
+        self.assertEqual(height, 240)
+        resp = self.request(path='/item/%s/tiles/zxy/0/0/0' % itemId,
+                            user=self.admin, isJson=False,
+                            params={'encoding': 'PNG', 'edge': 'yellow'})
+        self.assertStatusOk(resp)
+        image = self.getBody(resp, text=False)
+        self.assertEqual(image[:len(common.PNGHeader)], common.PNGHeader)
+        self.assertNotEqual(greyImage, image)
+
     def testTilesFromPIL(self):
         # Allow images bigger than our test
         from girder.plugins.large_image import constants

--- a/server/cache_util/cache.py
+++ b/server/cache_util/cache.py
@@ -17,9 +17,6 @@
 #  limitations under the License.
 ###############################################################################
 
-
-import six
-
 from cachetools import LRUCache, Cache, hashkey
 from .cachefactory import CacheFactory
 
@@ -28,14 +25,10 @@ def strhash(*args, **kwargs):
     return str(hashkey(*args, **kwargs))
 
 
-def defaultCacheKeyFunc(args, kwargs):
-    return (args, frozenset(six.viewitems(kwargs)))
-
-
 class LruCacheMetaclass(type):
     """
     """
-    caches = dict()
+    caches = {}
 
     def __new__(metacls, name, bases, namespace, **kwargs):  # noqa - N804
         # Get metaclass parameters by finding and removing them from the class
@@ -50,16 +43,6 @@ class LruCacheMetaclass(type):
 
         timeout = namespace.pop('cacheTimeout', None)
         timeout = kwargs.get('cacheTimeout', timeout)
-
-        keyFunc = namespace.pop('cacheKeyFunc', None)
-        keyFunc = kwargs.get('cacheKeyFunc', keyFunc)
-        # The @staticmethod wrapper stored the original function in __func__,
-        # and we need to use that as our keyFunc
-        if (hasattr(keyFunc, '__func__') and
-                hasattr(keyFunc.__func__, '__call__')):
-            keyFunc = keyFunc.__func__
-        if not keyFunc:
-            keyFunc = defaultCacheKeyFunc
 
         # TODO: use functools.lru_cache if's available in Python 3?
         cache = LRUCache(Cache(maxSize))

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -17,7 +17,6 @@
 #  limitations under the License.
 #############################################################################
 
-import abc
 import math
 from six import BytesIO
 
@@ -130,7 +129,6 @@ class TileSource(object):
         self.getTile = cached(
             self.cache, key=self.wrapKey, lock=self.cache_lock)(self.getTile)
 
-    @abc.abstractmethod
     def getState(self):
         return str(self.encoding) + ',' + str(self.jpegQuality) + ',' + str(
             self.jpegSubsampling) + ',' + str(self.edge)
@@ -1116,7 +1114,6 @@ class FileTileSource(TileSource):
         super(FileTileSource, self).__init__(*args, **kwargs)
         self.largeImagePath = path
 
-    @abc.abstractmethod
     def getState(self):
         return self._getLargeImagePath() + ',' + str(
             self.encoding) + ',' + str(self.jpegQuality) + ',' + str(
@@ -1152,7 +1149,6 @@ if girder:
             super(GirderTileSource, self).__init__(item, *args, **kwargs)
             self.item = item
 
-        @abc.abstractmethod
         def getState(self):
             return str(self.item['largeImage']['fileId']) + ',' + str(
                 self.item['updated']) + ',' + str(

--- a/web_client/js/imageViewerWidget/base.js
+++ b/web_client/js/imageViewerWidget/base.js
@@ -19,9 +19,23 @@ girder.views.ImageViewerWidget = girder.View.extend({
         }, this));
     },
 
-    _getTileUrl: function (level, x, y) {
-        return '/api/v1/item/' + this.itemId + '/tiles/zxy/' +
+    /**
+     * Return a url for a specific tile.  This can also be used to generate a
+     * template url if the level, x, and y parameters are template strings
+     * rather than integers.
+     *
+     * @param {number|string} level: the tile level or a template string.
+     * @param {number|string} x: the tile x position or a template string.
+     * @param {number|string} y: the tile y position or a template string.
+     * @param {object} [query]: optional query parameters to add to the url.
+     */
+    _getTileUrl: function (level, x, y, query) {
+        var url = '/api/v1/item/' + this.itemId + '/tiles/zxy/' +
             level + '/' + x + '/' + y;
+        if (query) {
+          url += '?' + $.param(query);
+        }
+        return url;
     },
 
     /**

--- a/web_client/js/imageViewerWidget/leaflet.js
+++ b/web_client/js/imageViewerWidget/leaflet.js
@@ -39,7 +39,7 @@ girder.views.LeafletImageViewerWidget = girder.views.ImageViewerWidget.extend({
             ],
             layers: [
                 L.tileLayer(
-                    this._getTileUrl('{z}', '{x}', '{y}') + '?edge=%23DDD', {
+                    this._getTileUrl('{z}', '{x}', '{y}', {edge: '#DDD'}), {
                     // in theory, tileSize: new L.Point(this.tileWidth,
                     // this.tileHeight) is supposed to support non-square
                     // tiles, but it doesn't work

--- a/web_client/js/imageViewerWidget/leaflet.js
+++ b/web_client/js/imageViewerWidget/leaflet.js
@@ -38,7 +38,8 @@ girder.views.LeafletImageViewerWidget = girder.views.ImageViewerWidget.extend({
                 [90.0, 180.0]
             ],
             layers: [
-                L.tileLayer(this._getTileUrl('{z}', '{x}', '{y}'), {
+                L.tileLayer(
+                    this._getTileUrl('{z}', '{x}', '{y}') + '?edge=%23DDD', {
                     // in theory, tileSize: new L.Point(this.tileWidth,
                     // this.tileHeight) is supposed to support non-square
                     // tiles, but it doesn't work

--- a/web_client/js/imageViewerWidget/openlayers.js
+++ b/web_client/js/imageViewerWidget/openlayers.js
@@ -29,7 +29,7 @@ girder.views.OpenlayersImageViewerWidget = girder.views.ImageViewerWidget.extend
                 new ol.layer.Tile({
                     source: new ol.source.XYZ({
                         tileSize: [this.tileWidth, this.tileHeight],
-                        url: this._getTileUrl('{z}', '{x}', '{y}'),
+                        url: this._getTileUrl('{z}', '{x}', '{y}') + '?edge=white',
                         crossOrigin: 'use-credentials',
                         maxZoom: this.levels,
                         wrapX: false

--- a/web_client/js/imageViewerWidget/openlayers.js
+++ b/web_client/js/imageViewerWidget/openlayers.js
@@ -29,7 +29,7 @@ girder.views.OpenlayersImageViewerWidget = girder.views.ImageViewerWidget.extend
                 new ol.layer.Tile({
                     source: new ol.source.XYZ({
                         tileSize: [this.tileWidth, this.tileHeight],
-                        url: this._getTileUrl('{z}', '{x}', '{y}') + '?edge=white',
+                        url: this._getTileUrl('{z}', '{x}', '{y}', {edge: 'white'}),
                         crossOrigin: 'use-credentials',
                         maxZoom: this.levels,
                         wrapX: false

--- a/web_client/js/imageViewerWidget/openseadragon.js
+++ b/web_client/js/imageViewerWidget/openseadragon.js
@@ -33,7 +33,9 @@ girder.views.OpenseadragonImageViewerWidget = girder.views.ImageViewerWidget.ext
                 tileHeight: this.tileHeight,
                 minLevel: 0,
                 maxLevel: this.levels - 1,
-                getTileUrl: _.bind(this._getTileUrl, this),
+                getTileUrl: _.bind(function (z, x, y) {
+                  return this._getTileUrl(z, x, y) + '?edge=crop';
+                }, this),
                 ajaxWithCredentials: true
             }
         });

--- a/web_client/js/imageViewerWidget/openseadragon.js
+++ b/web_client/js/imageViewerWidget/openseadragon.js
@@ -34,7 +34,7 @@ girder.views.OpenseadragonImageViewerWidget = girder.views.ImageViewerWidget.ext
                 minLevel: 0,
                 maxLevel: this.levels - 1,
                 getTileUrl: _.bind(function (z, x, y) {
-                  return this._getTileUrl(z, x, y) + '?edge=crop';
+                  return this._getTileUrl(z, x, y, {edge: 'crop'});
                 }, this),
                 ajaxWithCredentials: true
             }


### PR DESCRIPTION
Tiles at the right and bottom edges of images can now be cropped or have unused areas converted all to a specific color.  With appropriate query strings, this allows all viewers to show the edges of images in correct manner.

Some of the tile output code has been moved into the base class to avoid repetition.  As a benefit, the TIFF tilesource can output tiles as PNGs if so desired.

Removed some vestigial code related to class cache keys.