### PR TITLE
[WIP] Add a GET resource/:id/items endpoint.

### DIFF
--- a/plugin_tests/common.py
+++ b/plugin_tests/common.py
@@ -58,6 +58,8 @@ class LargeImageCommonTest(base.TestCase):
         for folder in folders:
             if folder['name'] == 'Public':
                 self.publicFolder = folder
+            if folder['name'] == 'Private':
+                self.privateFolder = folder
         # Authorize our user for Girder Worker
         resp = self.request(
             '/system/setting', method='PUT', user=self.admin, params={

--- a/plugin_tests/largeImageSpec.js
+++ b/plugin_tests/largeImageSpec.js
@@ -61,7 +61,7 @@ describe('Test the large image plugin', function () {
         });
         waitsFor(function () {
             var resp = girder.restRequest({
-                path: 'system/setting/large_image',
+                path: 'large_image/settings',
                 type: 'GET',
                 async: false
             });

--- a/plugin_tests/large_image_test.py
+++ b/plugin_tests/large_image_test.py
@@ -19,6 +19,7 @@
 
 import json
 import os
+import six
 import time
 
 from girder import config
@@ -75,6 +76,58 @@ class LargeImageLargeImageTest(common.LargeImageCommonTest):
             if resp.json.get('status') == JobStatus.CANCELED:
                 return 'canceled'
             time.sleep(0.1)
+
+    def testSettings(self):
+        from girder.plugins.large_image import constants
+        from girder.models.model_base import ValidationException
+
+        for key in (constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS,
+                    constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER,
+                    constants.PluginSettings.LARGE_IMAGE_AUTO_SET):
+            self.model('setting').set(key, 'false')
+            self.assertFalse(self.model('setting').get(key))
+            self.model('setting').set(key, 'true')
+            self.assertTrue(self.model('setting').get(key))
+            with six.assertRaisesRegex(self, ValidationException,
+                                       'must be a boolean'):
+                self.model('setting').set(key, 'not valid')
+        self.model('setting').set(
+            constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER, 'geojs')
+        self.assertEqual(self.model('setting').get(
+            constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER), 'geojs')
+        with six.assertRaisesRegex(self, ValidationException,
+                                   'must be a non-negative integer'):
+            self.model('setting').set(
+                constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES, -1)
+        self.model('setting').set(
+            constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES, 5)
+        self.assertEqual(self.model('setting').get(
+            constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES), 5)
+        with six.assertRaisesRegex(self, ValidationException,
+                                   'must be a non-negative integer'):
+            self.model('setting').set(
+                constants.PluginSettings.LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE, -1)
+        self.model('setting').set(
+            constants.PluginSettings.LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE, 1024)
+        self.assertEqual(self.model('setting').get(
+            constants.PluginSettings.LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE), 1024)
+        # Test the large_image/settings end point
+        resp = self.request(path='/large_image/settings', user=None)
+        self.assertStatusOk(resp)
+        settings = resp.json
+        # The values were set earlier
+        self.assertEqual(settings[
+            constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER], 'geojs')
+        self.assertEqual(settings[
+            constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER], True)
+        self.assertEqual(settings[
+            constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS], True)
+        self.assertEqual(settings[
+            constants.PluginSettings.LARGE_IMAGE_AUTO_SET], True)
+        self.assertEqual(settings[
+            constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES], 5)
+        self.assertEqual(settings[
+            constants.PluginSettings.LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE], 1024)
 
     def testThumbnailFileJob(self):
         # Create files via a job
@@ -195,3 +248,99 @@ class LargeImageLargeImageTest(common.LargeImageCommonTest):
         present, removed = self.model(
             'image_item', 'large_image').removeThumbnailFiles(item, keep=10)
         self.assertLess(present, 3 + len(slowList))
+
+
+# Test resource endpoints
+class LargeImageResourceTest(common.LargeImageCommonTest):
+    def testResourceItems(self):
+        # Create some resources to use in the tests
+        self.collection = self.model('collection').createCollection(
+            'collection A', self.admin)
+        self.colFolderA = self.model('folder').createFolder(
+            self.collection, 'folder A', parentType='collection',
+            creator=self.admin)
+        self.colFolderB = self.model('folder').createFolder(
+            self.collection, 'folder B', parentType='collection',
+            creator=self.admin)
+        self.colFolderC = self.model('folder').createFolder(
+            self.colFolderA, 'folder C', creator=self.admin)
+        self.colItemA1 = self.model('item').createItem(
+            'item A1', self.admin, self.colFolderA)
+        self.colItemB1 = self.model('item').createItem(
+            'item B1', self.admin, self.colFolderB)
+        self.colItemB2 = self.model('item').createItem(
+            'item B2', self.admin, self.colFolderB)
+        self.colItemC1 = self.model('item').createItem(
+            'item C1', self.admin, self.colFolderC)
+        self.colItemC2 = self.model('item').createItem(
+            'item C2', self.admin, self.colFolderC)
+        self.colItemC3 = self.model('item').createItem(
+            'item C3', self.admin, self.colFolderC)
+        self.itemPub1 = self.model('item').createItem(
+            'item Public 1', self.admin, self.publicFolder)
+        self.itemPriv1 = self.model('item').createItem(
+            'item Private 1', self.admin, self.privateFolder)
+        self.folderD = self.model('folder').createFolder(
+            self.publicFolder, 'folder D', creator=self.admin)
+        self.itemD1 = self.model('item').createItem(
+            'item D1', self.admin, self.folderD)
+        self.itemD2 = self.model('item').createItem(
+            'item D2', self.admin, self.folderD)
+        # Now test that we get the items we expect
+        # From a user
+        resp = self.request(
+            path='/resource/%s/items' % self.admin['_id'], user=self.admin,
+            params={'type': 'user'})
+        self.assertStatusOk(resp)
+        items = resp.json
+        self.assertEqual([item['name'] for item in items],
+                         ['item Public 1', 'item D1', 'item D2',
+                          'item Private 1'])
+        # From a collection
+        resp = self.request(
+            path='/resource/%s/items' % self.collection['_id'], user=self.admin,
+            params={'type': 'collection'})
+        self.assertStatusOk(resp)
+        items = resp.json
+        self.assertEqual([item['name'] for item in items],
+                         ['item A1', 'item C1', 'item C2', 'item C3',
+                          'item B1', 'item B2'])
+        # With sort, limit, and offset
+        resp = self.request(
+            path='/resource/%s/items' % self.collection['_id'], user=self.admin,
+            params={'type': 'collection', 'limit': 4, 'offset': 1,
+                    'sort': 'name', 'sortdir': -1})
+        self.assertStatusOk(resp)
+        items = resp.json
+        self.assertEqual([item['name'] for item in items],
+                         ['item B1', 'item A1', 'item C3', 'item C2'])
+        resp = self.request(
+            path='/resource/%s/items' % self.collection['_id'], user=self.admin,
+            params={'type': 'collection', 'limit': 1, 'offset': 0,
+                    'sort': 'name', 'sortdir': -1})
+        self.assertStatusOk(resp)
+        items = resp.json
+        self.assertEqual([item['name'] for item in items], ['item B2'])
+        # From a folder
+        resp = self.request(
+            path='/resource/%s/items' % self.colFolderA['_id'],
+            user=self.admin, params={'type': 'folder'})
+        self.assertStatusOk(resp)
+        items = resp.json
+        self.assertEqual([item['name'] for item in items],
+                         ['item A1', 'item C1', 'item C2', 'item C3'])
+        # From a lower folder
+        resp = self.request(
+            path='/resource/%s/items' % self.colFolderC['_id'],
+            user=self.admin, params={'type': 'folder'})
+        self.assertStatusOk(resp)
+        items = resp.json
+        self.assertEqual([item['name'] for item in items],
+                         ['item C1', 'item C2', 'item C3'])
+
+        # With a bad parameter
+        resp = self.request(
+            path='/resource/%s/items' % self.colFolderC['_id'],
+            user=self.admin, params={'type': 'collection'})
+        self.assertStatus(resp, 400)
+        self.assertIn('Resource not found', resp.json['message'])

--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -805,58 +805,6 @@ class LargeImageTilesTest(common.LargeImageCommonTest):
         self.assertEqual(width, 500)
         self.assertEqual(height, 375)
 
-    def testSettings(self):
-        from girder.plugins.large_image import constants
-        from girder.models.model_base import ValidationException
-
-        for key in (constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS,
-                    constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER,
-                    constants.PluginSettings.LARGE_IMAGE_AUTO_SET):
-            self.model('setting').set(key, 'false')
-            self.assertFalse(self.model('setting').get(key))
-            self.model('setting').set(key, 'true')
-            self.assertTrue(self.model('setting').get(key))
-            with six.assertRaisesRegex(self, ValidationException,
-                                       'must be a boolean'):
-                self.model('setting').set(key, 'not valid')
-        self.model('setting').set(
-            constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER, 'geojs')
-        self.assertEqual(self.model('setting').get(
-            constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER), 'geojs')
-        with six.assertRaisesRegex(self, ValidationException,
-                                   'must be a non-negative integer'):
-            self.model('setting').set(
-                constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES, -1)
-        self.model('setting').set(
-            constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES, 5)
-        self.assertEqual(self.model('setting').get(
-            constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES), 5)
-        with six.assertRaisesRegex(self, ValidationException,
-                                   'must be a non-negative integer'):
-            self.model('setting').set(
-                constants.PluginSettings.LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE, -1)
-        self.model('setting').set(
-            constants.PluginSettings.LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE, 1024)
-        self.assertEqual(self.model('setting').get(
-            constants.PluginSettings.LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE), 1024)
-        # Test the system/setting/large_image end point
-        resp = self.request(path='/system/setting/large_image', user=None)
-        self.assertStatusOk(resp)
-        settings = resp.json
-        # The values were set earlier
-        self.assertEqual(settings[
-            constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER], 'geojs')
-        self.assertEqual(settings[
-            constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER], True)
-        self.assertEqual(settings[
-            constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS], True)
-        self.assertEqual(settings[
-            constants.PluginSettings.LARGE_IMAGE_AUTO_SET], True)
-        self.assertEqual(settings[
-            constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES], 5)
-        self.assertEqual(settings[
-            constants.PluginSettings.LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE], 1024)
-
     def testGetTileSource(self):
         from girder.plugins.large_image.tilesource import getTileSource
 

--- a/server/base.py
+++ b/server/base.py
@@ -198,7 +198,7 @@ def load(info):
     from .rest import TilesItemResource, LargeImageResource, AnnotationResource
 
     TilesItemResource(info['apiRoot'])
-    info['apiRoot'].large_image = LargeImageResource()
+    info['apiRoot'].large_image = LargeImageResource(info['apiRoot'])
     info['apiRoot'].annotation = AnnotationResource()
 
     ModelImporter.model('item').exposeFields(

--- a/server/rest/tiles.py
+++ b/server/rest/tiles.py
@@ -28,7 +28,7 @@ from girder.models.model_base import AccessType
 
 from ..models import TileGeneralException
 
-from .. import constants, loadmodelcache
+from .. import loadmodelcache
 
 
 class TilesItemResource(Item):
@@ -54,9 +54,6 @@ class TilesItemResource(Item):
         filter_logging.addLoggingFilter(
             'GET (/[^/ ?#]+)*/item/[^/ ?#]+/tiles/zxy(/[^/ ?#]+){3}',
             frequency=250)
-        # This is added to the system route
-        apiRoot.system.route('GET', ('setting', 'large_image'),
-                             self.getPublicSettings)
         # Cache the model singleton
         self.imageItemModel = self.model('image_item', 'large_image')
 
@@ -405,18 +402,3 @@ class TilesItemResource(Item):
         setResponseHeader('Content-Type', regionMime)
         setRawResponse()
         return regionData
-
-    @describeRoute(
-        Description('Get public settings for large image display.')
-    )
-    @access.public
-    def getPublicSettings(self, params):
-        keys = [
-            constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS,
-            constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER,
-            constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER,
-            constants.PluginSettings.LARGE_IMAGE_AUTO_SET,
-            constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES,
-            constants.PluginSettings.LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE,
-        ]
-        return {k: self.model('setting').get(k) for k in keys}

--- a/web_client/js/configView.js
+++ b/web_client/js/configView.js
@@ -120,7 +120,7 @@ girder.views.largeImageConfig = girder.View.extend({
         if (!girder.views.largeImageConfig.settings) {
             girder.restRequest({
                 type: 'GET',
-                path: 'system/setting/large_image'
+                path: 'large_image/settings'
             }).done(function (resp) {
                 girder.views.largeImageConfig.settings = resp;
                 if (callback) {


### PR DESCRIPTION
Recursively get all items within a resource and its child folders.  The resource can be a folder, collection, or user.

Also, moved GET system/setting/large_image to GET large_image/settings to keep the namespace cleaner.