### PR TITLE
Fix some caching issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,8 +112,6 @@ before_install:
   - girder_worker_path=$girder_path/plugins/girder_worker
   - git clone https://github.com/girder/girder_worker.git $girder_worker_path && git -C $girder_worker_path checkout $GIRDER_WORKER_VERSION
   - cp $PWD/plugin_tests/test_files/girder_worker.cfg $girder_worker_path/girder_worker/worker.local.cfg
-  # Work around a failed wheel on pycparser - see https://github.com/pyca/cryptography/issues/3187
-  - pip install --no-cache-dir -U cryptography==1.4 --no-binary pycparser
   - pip install --no-cache-dir -U -r $girder_worker_path/requirements.txt -r $girder_worker_path/girder_worker/plugins/girder_io/requirements.txt
 
   - export MONGO_VERSION=3.0.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,6 +112,8 @@ before_install:
   - girder_worker_path=$girder_path/plugins/girder_worker
   - git clone https://github.com/girder/girder_worker.git $girder_worker_path && git -C $girder_worker_path checkout $GIRDER_WORKER_VERSION
   - cp $PWD/plugin_tests/test_files/girder_worker.cfg $girder_worker_path/girder_worker/worker.local.cfg
+  # Work around a failed wheel on pycparser - see https://github.com/pyca/cryptography/issues/3187
+  - pip install --no-cache-dir -U cryptography==1.4 --no-binary pycparser
   - pip install --no-cache-dir -U -r $girder_worker_path/requirements.txt -r $girder_worker_path/girder_worker/plugins/girder_io/requirements.txt
 
   - export MONGO_VERSION=3.0.7

--- a/plugin_tests/cached_tiles_test.py
+++ b/plugin_tests/cached_tiles_test.py
@@ -47,33 +47,32 @@ def tearDownModule():
 
 class LargeImageCachedTilesTest(common.LargeImageCommonTest):
     def _monitorTileCounts(self):
-        if hasattr(self, 'tileCounter'):
-            return
-        from girder.plugins.large_image.tilesource.test import TestTileSource
-        originalGetTile = TestTileSource.getTile
-        originalWrapKey = TestTileSource.wrapKey
-        self.tileCounter = 0
-        self.keyPrefix = str(time.time())
+        from girder.plugins.large_image.tilesource import test
+        test.tileCounter = 0
 
-        def countGetTile(ttsself, *args, **kwargs):
-            # Increment the counter after the call, so that exceptions won't
-            # increment it.
-            result = originalGetTile(ttsself, *args, **kwargs)
-            self.tileCounter += 1
-            return result
+        self.originalWrapKey = test.TestTileSource.wrapKey
+        self.keyPrefix = str(time.time())
 
         def wrapKey(*args, **kwargs):
             # Ensure that this test has unique keys
-            return self.keyPrefix + originalWrapKey(*args, **kwargs)
+            return self.keyPrefix + self.originalWrapKey(*args, **kwargs)
 
-        TestTileSource.getTile = countGetTile
-        TestTileSource.wrapKey = wrapKey
+        test.TestTileSource.wrapKey = wrapKey
+
+    def _stopMonitorTileCounts(self):
+        from girder.plugins.large_image.tilesource.test import TestTileSource
+        TestTileSource.wrapKey = self.originalWrapKey
 
     def setUp(self):
         self._monitorTileCounts()
         common.LargeImageCommonTest.setUp(self)
 
+    def tearDown(self):
+        self._stopMonitorTileCounts()
+
     def testTilesFromTest(self):
+        from girder.plugins.large_image.tilesource import test
+
         # Create a test tile with the default options
         params = {'encoding': 'JPEG'}
         meta = self._createTestTiles(params, {
@@ -82,11 +81,11 @@ class LargeImageCachedTilesTest(common.LargeImageCommonTest):
         })
         self._testTilesZXY('test', meta, params)
         # We should have generated tiles
-        self.assertGreater(self.tileCounter, 0)
-        counter1 = self.tileCounter
+        self.assertGreater(test.tileCounter, 0)
+        counter1 = test.tileCounter
         # Running a second time should take entirely from cache
         self._testTilesZXY('test', meta, params)
-        self.assertEqual(self.tileCounter, counter1)
+        self.assertEqual(test.tileCounter, counter1)
 
         # Test most of our parameters in a single special case
         params = {
@@ -105,11 +104,11 @@ class LargeImageCachedTilesTest(common.LargeImageCommonTest):
         meta['minLevel'] = 2
         self._testTilesZXY('test', meta, params)
         # We should have generated tiles
-        self.assertGreater(self.tileCounter, counter1)
-        counter2 = self.tileCounter
+        self.assertGreater(test.tileCounter, counter1)
+        counter2 = test.tileCounter
         # Running a second time should take entirely from cache
         self._testTilesZXY('test', meta, params)
-        self.assertEqual(self.tileCounter, counter2)
+        self.assertEqual(test.tileCounter, counter2)
 
         # Test the fractal tiles with PNG
         params = {'fractal': 'true'}
@@ -119,11 +118,11 @@ class LargeImageCachedTilesTest(common.LargeImageCommonTest):
         })
         self._testTilesZXY('test', meta, params, common.PNGHeader)
         # We should have generated tiles
-        self.assertGreater(self.tileCounter, counter2)
-        counter3 = self.tileCounter
+        self.assertGreater(test.tileCounter, counter2)
+        counter3 = test.tileCounter
         # Running a second time should take entirely from cache
         self._testTilesZXY('test', meta, params, common.PNGHeader)
-        self.assertEqual(self.tileCounter, counter3)
+        self.assertEqual(test.tileCounter, counter3)
 
     def testLargeRegion(self):
         # Create a test tile with the default options

--- a/server/cache_util/__init__.py
+++ b/server/cache_util/__init__.py
@@ -17,7 +17,7 @@
 #  limitations under the License.
 ###############################################################################
 
-from .cache import LruCacheMetaclass, tileCache, tileLock, strhash
+from .cache import LruCacheMetaclass, tileCache, tileLock, strhash, methodcache
 try:
     from .memcache import MemCache
 except ImportError:
@@ -28,4 +28,4 @@ from cachetools import cached, Cache, LRUCache
 
 __all__ = ('CacheFactory', 'tileCache', 'tileLock', 'MemCache', 'strhash',
            'LruCacheMetaclass', 'pickAvailableCache', 'cached', 'Cache',
-           'LRUCache')
+           'LRUCache', 'methodcache')

--- a/server/cache_util/cache.py
+++ b/server/cache_util/cache.py
@@ -63,7 +63,10 @@ class LruCacheMetaclass(type):
 
         cache = LruCacheMetaclass.caches[cls]
 
-        key = strhash(args[0], kwargs)
+        if hasattr(cls, 'getLRUHash'):
+            key = cls.getLRUHash(*args, **kwargs)
+        else:
+            key = strhash(args[0], kwargs)
         try:
             instance = cache[key]
         except KeyError:

--- a/server/cache_util/cachefactory.py
+++ b/server/cache_util/cachefactory.py
@@ -40,7 +40,7 @@ except ImportError:
     psutil = None
 
 
-def pickAvailableCache(sizeEach, portion=8):
+def pickAvailableCache(sizeEach, portion=8, maxItems=None):
     """
     Given an estimated size of an item, return how many of those items would
     fit in a fixed portion of the available virtual memory.
@@ -55,6 +55,8 @@ def pickAvailableCache(sizeEach, portion=8):
     else:
         memory = 1024 ** 3
     numItems = max(int(math.floor(memory / portion / sizeEach)), 2)
+    if maxItems:
+        numItems = max(numItems, maxItems)
     return numItems
 
 

--- a/server/cache_util/cachefactory.py
+++ b/server/cache_util/cachefactory.py
@@ -56,7 +56,7 @@ def pickAvailableCache(sizeEach, portion=8, maxItems=None):
         memory = 1024 ** 3
     numItems = max(int(math.floor(memory / portion / sizeEach)), 2)
     if maxItems:
-        numItems = max(numItems, maxItems)
+        numItems = min(numItems, maxItems)
     return numItems
 
 

--- a/server/cache_util/cachefactory.py
+++ b/server/cache_util/cachefactory.py
@@ -47,7 +47,10 @@ def pickAvailableCache(sizeEach, portion=8, maxItems=None):
 
     :param sizeEach: the expected size of an item that could be cached.
     :param portion: the inverse fraction of the memory which can be used.
-    :return: the number of items that should be cached.  Always at least two.
+    :param maxItems: if specified, the number of items is never more than this
+        value.
+    :return: the number of items that should be cached.  Always at least two,
+        unless maxItems is less.
     """
     # Estimate usage based on (1 / portion) of the total virtual memory.
     if psutil:

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -20,7 +20,7 @@
 import math
 from six import BytesIO
 
-from ..cache_util import tileCache, tileLock, strhash, cached
+from ..cache_util import tileCache, tileLock, strhash, methodcache
 
 try:
     import girder
@@ -123,11 +123,13 @@ class TileSource(object):
         self.jpegSubsampling = int(jpegSubsampling)
         self.edge = edge
 
+        """
         self.getThumbnail = cached(
             self.cache, key=self.wrapKey, lock=self.cache_lock)(
                 self.getThumbnail)
         self.getTile = cached(
             self.cache, key=self.wrapKey, lock=self.cache_lock)(self.getTile)
+        """
 
     @staticmethod
     def getLRUHash(*args, **kwargs):
@@ -647,6 +649,7 @@ class TileSource(object):
             'mm_y': mag['mm_y'],
         }
 
+    @methodcache(lock=True)
     def getTile(self, x, y, z, pilImageAllowed=False, sparseFallback=False):
         raise NotImplementedError()
 
@@ -655,6 +658,7 @@ class TileSource(object):
             return 'image/png'
         return 'image/jpeg'
 
+    @methodcache(lock=True)
     def getThumbnail(self, width=None, height=None, levelZero=False, **kwargs):
         """
         Get a basic thumbnail from the current tile source.  Aspect ratio is

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -712,7 +712,7 @@ class TileSource(object):
             'mm_y': mag['mm_y'],
         }
 
-    @methodcache(lock=True)
+    @methodcache()
     def getTile(self, x, y, z, pilImageAllowed=False, sparseFallback=False):
         raise NotImplementedError()
 
@@ -721,7 +721,7 @@ class TileSource(object):
             return 'image/png'
         return 'image/jpeg'
 
-    @methodcache(lock=True)
+    @methodcache()
     def getThumbnail(self, width=None, height=None, levelZero=False, **kwargs):
         """
         Get a basic thumbnail from the current tile source.  Aspect ratio is

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -129,6 +129,12 @@ class TileSource(object):
         self.getTile = cached(
             self.cache, key=self.wrapKey, lock=self.cache_lock)(self.getTile)
 
+    @staticmethod
+    def getLRUHash(*args, **kwargs):
+        return strhash(
+            kwargs.get('encoding'), kwargs.get('jpegQuality'),
+            kwargs.get('jpegSubsampling'), kwargs.get('edge'))
+
     def getState(self):
         return str(self.encoding) + ',' + str(self.jpegQuality) + ',' + str(
             self.jpegSubsampling) + ',' + str(self.edge)
@@ -1114,6 +1120,12 @@ class FileTileSource(TileSource):
         super(FileTileSource, self).__init__(*args, **kwargs)
         self.largeImagePath = path
 
+    @staticmethod
+    def getLRUHash(*args, **kwargs):
+        return strhash(
+            args[0], kwargs.get('encoding'), kwargs.get('jpegQuality'),
+            kwargs.get('jpegSubsampling'), kwargs.get('edge'))
+
     def getState(self):
         return self._getLargeImagePath() + ',' + str(
             self.encoding) + ',' + str(self.jpegQuality) + ',' + str(
@@ -1148,6 +1160,13 @@ if girder:
         def __init__(self, item, *args, **kwargs):
             super(GirderTileSource, self).__init__(item, *args, **kwargs)
             self.item = item
+
+        @staticmethod
+        def getLRUHash(*args, **kwargs):
+            return strhash(
+                str(args[0]['largeImage']['fileId']), args[0]['updated'],
+                kwargs.get('encoding'), kwargs.get('jpegQuality'),
+                kwargs.get('jpegSubsampling'), kwargs.get('edge'))
 
         def getState(self):
             return str(self.item['largeImage']['fileId']) + ',' + str(

--- a/server/tilesource/pil.py
+++ b/server/tilesource/pil.py
@@ -124,7 +124,7 @@ class PILFileTileSource(FileTileSource):
         return super(PILFileTileSource, self).getState() + ',' + str(
             self.maxSize)
 
-    @methodcache(lock=True)
+    @methodcache()
     def getTile(self, x, y, z, pilImageAllowed=False, **kwargs):
         if z != 0:
             raise TileSourceException('z layer does not exist')

--- a/server/tilesource/pil.py
+++ b/server/tilesource/pil.py
@@ -24,7 +24,8 @@ import six
 import PIL.Image
 
 from .base import FileTileSource, TileSourceException
-from ..cache_util import LruCacheMetaclass, pickAvailableCache, strhash
+from ..cache_util import LruCacheMetaclass, pickAvailableCache, strhash, \
+    methodcache
 
 try:
     import girder
@@ -123,6 +124,7 @@ class PILFileTileSource(FileTileSource):
         return super(PILFileTileSource, self).getState() + ',' + str(
             self.maxSize)
 
+    @methodcache(lock=True)
     def getTile(self, x, y, z, pilImageAllowed=False, **kwargs):
         if z != 0:
             raise TileSourceException('z layer does not exist')

--- a/server/tilesource/pil.py
+++ b/server/tilesource/pil.py
@@ -24,7 +24,7 @@ import six
 import PIL.Image
 
 from .base import FileTileSource, TileSourceException
-from ..cache_util import LruCacheMetaclass, pickAvailableCache
+from ..cache_util import LruCacheMetaclass, pickAvailableCache, strhash
 
 try:
     import girder
@@ -112,10 +112,16 @@ class PILFileTileSource(FileTileSource):
         if self.tileWidth > maxWidth or self.tileHeight > maxHeight:
             raise TileSourceException('PIL tile size is too large.')
 
+    @staticmethod
+    def getLRUHash(*args, **kwargs):
+        return strhash(
+            super(PILFileTileSource, PILFileTileSource).getLRUHash(
+                *args, **kwargs),
+            kwargs.get('maxSize'))
+
     def getState(self):
         return super(PILFileTileSource, self).getState() + ',' + str(
-            self.encoding) + ',' + str(self.jpegQuality) + ',' + str(
-            self.jpegSubsampling) + ',' + str(self.edge)
+            self.maxSize)
 
     def getTile(self, x, y, z, pilImageAllowed=False, **kwargs):
         if z != 0:
@@ -138,3 +144,14 @@ if girder:
         cacheMaxSize = pickAvailableCache(1024 ** 2)
         cacheTimeout = 300
         name = 'pil'
+
+        @staticmethod
+        def getLRUHash(*args, **kwargs):
+            return strhash(
+                super(PILGirderTileSource, PILGirderTileSource).getLRUHash(
+                    *args, **kwargs),
+                kwargs.get('maxSize'))
+
+        def getState(self):
+            return super(PILGirderTileSource, self).getState() + ',' + str(
+                self.maxSize)

--- a/server/tilesource/svs.py
+++ b/server/tilesource/svs.py
@@ -26,7 +26,7 @@ import openslide
 import PIL
 
 from .base import FileTileSource, TileSourceException
-from ..cache_util import LruCacheMetaclass, pickAvailableCache
+from ..cache_util import LruCacheMetaclass, pickAvailableCache, methodcache
 
 try:
     import girder
@@ -139,6 +139,7 @@ class SVSFileTileSource(FileTileSource):
             'mm_y': mm_y,
         }
 
+    @methodcache(lock=True)
     def getTile(self, x, y, z, pilImageAllowed=False, **kwargs):
         if z < 0:
             raise TileSourceException('z layer does not exist')

--- a/server/tilesource/svs.py
+++ b/server/tilesource/svs.py
@@ -139,7 +139,7 @@ class SVSFileTileSource(FileTileSource):
             'mm_y': mm_y,
         }
 
-    @methodcache(lock=True)
+    @methodcache()
     def getTile(self, x, y, z, pilImageAllowed=False, **kwargs):
         if z < 0:
             raise TileSourceException('z layer does not exist')

--- a/server/tilesource/test.py
+++ b/server/tilesource/test.py
@@ -19,6 +19,7 @@
 
 import colorsys
 from .base import TileSource, TileSourceException
+from ..cache_util import strhash
 
 import PIL
 from PIL import Image, ImageDraw, ImageFont
@@ -134,6 +135,15 @@ class TestTileSource(TileSource):
             font=imageDrawFont
         )
         return self._outputTile(image, 'PIL', x, y, z, **kwargs)
+
+    @staticmethod
+    def getLRUHash(*args, **kwargs):
+        return strhash(
+            super(TestTileSource, TestTileSource).getLRUHash(
+                *args, **kwargs),
+            kwargs.get('minLevel'), kwargs.get('maxLevel'),
+            kwargs.get('tileWidth'), kwargs.get('tileHeight'),
+            kwargs.get('fractal'))
 
     def getState(self):
         return 'test %r %r %r %r %r %r' % (

--- a/server/tilesource/test.py
+++ b/server/tilesource/test.py
@@ -18,8 +18,10 @@
 ###############################################################################
 
 import colorsys
+import six
 from .base import TileSource, TileSourceException
-from ..cache_util import strhash, methodcache
+from ..cache_util import strhash, methodcache, LruCacheMetaclass, \
+    pickAvailableCache
 
 import PIL
 from PIL import Image, ImageDraw, ImageFont
@@ -27,7 +29,14 @@ if int(PIL.PILLOW_VERSION.split('.')[0]) < 3:
     raise ImportError('Pillow v3.0 or later is required')
 
 
+# Used in testing
+tileCounter = 0
+
+
+@six.add_metaclass(LruCacheMetaclass)
 class TestTileSource(TileSource):
+    cacheMaxSize = pickAvailableCache(1024 ** 2)
+    cacheTimeout = 300
     name = 'test'
 
     def __init__(self, ignored_path=None, minLevel=0, maxLevel=9,
@@ -88,7 +97,7 @@ class TestTileSource(TileSource):
                             ], color, None)
             sq /= 2
 
-    @methodcache(lock=True)
+    @methodcache()
     def getTile(self, x, y, z, *args, **kwargs):
         widthCount = 2 ** z
 
@@ -135,6 +144,8 @@ class TestTileSource(TileSource):
             fill=(0, 0, 0),
             font=imageDrawFont
         )
+        global tileCounter
+        tileCounter += 1
         return self._outputTile(image, 'PIL', x, y, z, **kwargs)
 
     @staticmethod

--- a/server/tilesource/test.py
+++ b/server/tilesource/test.py
@@ -19,7 +19,7 @@
 
 import colorsys
 from .base import TileSource, TileSourceException
-from ..cache_util import strhash
+from ..cache_util import strhash, methodcache
 
 import PIL
 from PIL import Image, ImageDraw, ImageFont
@@ -88,6 +88,7 @@ class TestTileSource(TileSource):
                             ], color, None)
             sq /= 2
 
+    @methodcache(lock=True)
     def getTile(self, x, y, z, *args, **kwargs):
         widthCount = 2 ** z
 

--- a/server/tilesource/tiff.py
+++ b/server/tilesource/tiff.py
@@ -23,7 +23,7 @@ import six
 from six import BytesIO
 
 from .base import FileTileSource, TileSourceException
-from ..cache_util import pickAvailableCache, LruCacheMetaclass
+from ..cache_util import pickAvailableCache, LruCacheMetaclass, methodcache
 from .tiff_reader import TiledTiffDirectory, TiffException, \
     InvalidOperationTiffException, IOTiffException
 
@@ -58,7 +58,7 @@ class TiffFileTileSource(FileTileSource):
         largeImagePath = self._getLargeImagePath()
         lastException = None
 
-        self._tiffDirectories = list()
+        self._tiffDirectories = []
         for directoryNum in itertools.count():
             try:
                 tiffDirectory = TiledTiffDirectory(largeImagePath, directoryNum)
@@ -100,6 +100,7 @@ class TiffFileTileSource(FileTileSource):
             'mm_y': mm_y,
         }
 
+    @methodcache(lock=True)
     def getTile(self, x, y, z, pilImageAllowed=False, sparseFallback=False,
                 **kwargs):
         try:

--- a/server/tilesource/tiff.py
+++ b/server/tilesource/tiff.py
@@ -100,7 +100,7 @@ class TiffFileTileSource(FileTileSource):
             'mm_y': mm_y,
         }
 
-    @methodcache(lock=True)
+    @methodcache()
     def getTile(self, x, y, z, pilImageAllowed=False, sparseFallback=False,
                 **kwargs):
         try:

--- a/server/tilesource/tiff.py
+++ b/server/tilesource/tiff.py
@@ -48,7 +48,7 @@ class TiffFileTileSource(FileTileSource):
     """
     # Cache size is based on what the class needs, which does not include
     # individual tiles
-    cacheMaxSize = pickAvailableCache(1024 ** 2)
+    cacheMaxSize = pickAvailableCache(1024 ** 2, 100)
     cacheTimeout = 300
     name = 'tifffile'
 


### PR DESCRIPTION
The LRU cache was using the wrong key.

The metaclass cache was using some of the query parameters for the keys, resulting in few cache hits for certain functions (like `getRegion`).  This fixes the cache keys.

Fix some caching issues.

Because of how the `cached` function from cachetools was being applied to class methods, those instantiated classes would never be garbage collected.  This led to leaving files open and exhausting resources.  A new decorator was added called `methodcache` which behaves akin to the `cachetools.cached` decorator, except that it uses class caches, locks, and, optionally, key functions.

This still needs tests.