### PR TITLE
Move the settings endpoint.

### DIFF
--- a/plugin_tests/common.py
+++ b/plugin_tests/common.py
@@ -58,6 +58,8 @@ class LargeImageCommonTest(base.TestCase):
         for folder in folders:
             if folder['name'] == 'Public':
                 self.publicFolder = folder
+            if folder['name'] == 'Private':
+                self.privateFolder = folder
         # Authorize our user for Girder Worker
         resp = self.request(
             '/system/setting', method='PUT', user=self.admin, params={

--- a/plugin_tests/largeImageSpec.js
+++ b/plugin_tests/largeImageSpec.js
@@ -61,7 +61,7 @@ describe('Test the large image plugin', function () {
         });
         waitsFor(function () {
             var resp = girder.restRequest({
-                path: 'system/setting/large_image',
+                path: 'large_image/settings',
                 type: 'GET',
                 async: false
             });

--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -805,58 +805,6 @@ class LargeImageTilesTest(common.LargeImageCommonTest):
         self.assertEqual(width, 500)
         self.assertEqual(height, 375)
 
-    def testSettings(self):
-        from girder.plugins.large_image import constants
-        from girder.models.model_base import ValidationException
-
-        for key in (constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS,
-                    constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER,
-                    constants.PluginSettings.LARGE_IMAGE_AUTO_SET):
-            self.model('setting').set(key, 'false')
-            self.assertFalse(self.model('setting').get(key))
-            self.model('setting').set(key, 'true')
-            self.assertTrue(self.model('setting').get(key))
-            with six.assertRaisesRegex(self, ValidationException,
-                                       'must be a boolean'):
-                self.model('setting').set(key, 'not valid')
-        self.model('setting').set(
-            constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER, 'geojs')
-        self.assertEqual(self.model('setting').get(
-            constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER), 'geojs')
-        with six.assertRaisesRegex(self, ValidationException,
-                                   'must be a non-negative integer'):
-            self.model('setting').set(
-                constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES, -1)
-        self.model('setting').set(
-            constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES, 5)
-        self.assertEqual(self.model('setting').get(
-            constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES), 5)
-        with six.assertRaisesRegex(self, ValidationException,
-                                   'must be a non-negative integer'):
-            self.model('setting').set(
-                constants.PluginSettings.LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE, -1)
-        self.model('setting').set(
-            constants.PluginSettings.LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE, 1024)
-        self.assertEqual(self.model('setting').get(
-            constants.PluginSettings.LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE), 1024)
-        # Test the system/setting/large_image end point
-        resp = self.request(path='/system/setting/large_image', user=None)
-        self.assertStatusOk(resp)
-        settings = resp.json
-        # The values were set earlier
-        self.assertEqual(settings[
-            constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER], 'geojs')
-        self.assertEqual(settings[
-            constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER], True)
-        self.assertEqual(settings[
-            constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS], True)
-        self.assertEqual(settings[
-            constants.PluginSettings.LARGE_IMAGE_AUTO_SET], True)
-        self.assertEqual(settings[
-            constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES], 5)
-        self.assertEqual(settings[
-            constants.PluginSettings.LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE], 1024)
-
     def testGetTileSource(self):
         from girder.plugins.large_image.tilesource import getTileSource
 

--- a/server/base.py
+++ b/server/base.py
@@ -198,7 +198,7 @@ def load(info):
     from .rest import TilesItemResource, LargeImageResource, AnnotationResource
 
     TilesItemResource(info['apiRoot'])
-    info['apiRoot'].large_image = LargeImageResource()
+    info['apiRoot'].large_image = LargeImageResource(info['apiRoot'])
     info['apiRoot'].annotation = AnnotationResource()
 
     ModelImporter.model('item').exposeFields(

--- a/server/base.py
+++ b/server/base.py
@@ -198,7 +198,7 @@ def load(info):
     from .rest import TilesItemResource, LargeImageResource, AnnotationResource
 
     TilesItemResource(info['apiRoot'])
-    info['apiRoot'].large_image = LargeImageResource(info['apiRoot'])
+    info['apiRoot'].large_image = LargeImageResource()
     info['apiRoot'].annotation = AnnotationResource()
 
     ModelImporter.model('item').exposeFields(

--- a/server/rest/large_image.py
+++ b/server/rest/large_image.py
@@ -83,7 +83,7 @@ def createThumbnailsJob(job):
 
 class LargeImageResource(Resource):
 
-    def __init__(self, apiRoot):
+    def __init__(self):
         super(LargeImageResource, self).__init__()
 
         self.resourceName = 'large_image'

--- a/server/rest/large_image.py
+++ b/server/rest/large_image.py
@@ -83,13 +83,29 @@ def createThumbnailsJob(job):
 
 class LargeImageResource(Resource):
 
-    def __init__(self):
+    def __init__(self, apiRoot):
         super(LargeImageResource, self).__init__()
 
         self.resourceName = 'large_image'
+        self.route('GET', ('settings',), self.getPublicSettings)
         self.route('GET', ('thumbnails',), self.countThumbnails)
         self.route('PUT', ('thumbnails',), self.createThumbnails)
         self.route('DELETE', ('thumbnails',), self.deleteThumbnails)
+
+    @describeRoute(
+        Description('Get public settings for large image display.')
+    )
+    @access.public
+    def getPublicSettings(self, params):
+        keys = [
+            constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS,
+            constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER,
+            constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER,
+            constants.PluginSettings.LARGE_IMAGE_AUTO_SET,
+            constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES,
+            constants.PluginSettings.LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE,
+        ]
+        return {k: self.model('setting').get(k) for k in keys}
 
     @describeRoute(
         Description('Count the number of cached thumbnail files for '

--- a/server/rest/tiles.py
+++ b/server/rest/tiles.py
@@ -28,7 +28,7 @@ from girder.models.model_base import AccessType
 
 from ..models import TileGeneralException
 
-from .. import constants, loadmodelcache
+from .. import loadmodelcache
 
 
 class TilesItemResource(Item):
@@ -54,9 +54,6 @@ class TilesItemResource(Item):
         filter_logging.addLoggingFilter(
             'GET (/[^/ ?#]+)*/item/[^/ ?#]+/tiles/zxy(/[^/ ?#]+){3}',
             frequency=250)
-        # This is added to the system route
-        apiRoot.system.route('GET', ('setting', 'large_image'),
-                             self.getPublicSettings)
         # Cache the model singleton
         self.imageItemModel = self.model('image_item', 'large_image')
 
@@ -405,18 +402,3 @@ class TilesItemResource(Item):
         setResponseHeader('Content-Type', regionMime)
         setRawResponse()
         return regionData
-
-    @describeRoute(
-        Description('Get public settings for large image display.')
-    )
-    @access.public
-    def getPublicSettings(self, params):
-        keys = [
-            constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS,
-            constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER,
-            constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER,
-            constants.PluginSettings.LARGE_IMAGE_AUTO_SET,
-            constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES,
-            constants.PluginSettings.LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE,
-        ]
-        return {k: self.model('setting').get(k) for k in keys}

--- a/web_client/js/configView.js
+++ b/web_client/js/configView.js
@@ -120,7 +120,7 @@ girder.views.largeImageConfig = girder.View.extend({
         if (!girder.views.largeImageConfig.settings) {
             girder.restRequest({
                 type: 'GET',
-                path: 'system/setting/large_image'
+                path: 'large_image/settings'
             }).done(function (resp) {
                 girder.views.largeImageConfig.settings = resp;
                 if (callback) {


### PR DESCRIPTION
Move GET system/setting/large_image to GET large_image/settings to keep the namespace cleaner.