### PR TITLE
Better tile source caching.

### DIFF
--- a/plugin_tests/cached_tiles_test.py
+++ b/plugin_tests/cached_tiles_test.py
@@ -177,7 +177,7 @@ class LargeImageCachedTilesTest(common.LargeImageCommonTest):
         itemId = str(file['itemId'])
         item = self.model('item').load(itemId, user=self.admin)
         # Clear the cache to free references and force garbage collection
-        LruCacheMetaclass.caches[TiffGirderTileSource].clear()
+        LruCacheMetaclass.classCaches[TiffGirderTileSource].clear()
         gc.collect(2)
         self.initCount = 0
         self.delCount = 0
@@ -191,7 +191,7 @@ class LargeImageCachedTilesTest(common.LargeImageCommonTest):
         self.assertEqual(self.initCount, 10)
         source = None
         # Clear the cache to free references and force garbage collection
-        LruCacheMetaclass.caches[TiffGirderTileSource].clear()
+        LruCacheMetaclass.classCaches[TiffGirderTileSource].clear()
         gc.collect(2)
         self.assertEqual(self.delCount, 10)
 

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -1206,6 +1206,7 @@ class TileSource(object):
 
 
 class FileTileSource(TileSource):
+
     def __init__(self, path, *args, **kwargs):
         super(FileTileSource, self).__init__(*args, **kwargs)
         self.largeImagePath = path

--- a/server/tilesource/pil.py
+++ b/server/tilesource/pil.py
@@ -24,8 +24,7 @@ import six
 import PIL.Image
 
 from .base import FileTileSource, TileSourceException
-from ..cache_util import LruCacheMetaclass, pickAvailableCache, strhash, \
-    methodcache
+from ..cache_util import LruCacheMetaclass, strhash, methodcache
 
 try:
     import girder
@@ -68,10 +67,7 @@ class PILFileTileSource(FileTileSource):
     """
     Provides tile access to single image PIL files.
     """
-    # Cache size is based on what the class needs, which does not include
-    # individual tiles
-    cacheMaxSize = pickAvailableCache(1024 ** 2)
-    cacheTimeout = 300
+    cacheName = 'tilesource'
     name = 'pilfile'
 
     def __init__(self, path, maxSize=None, **kwargs):
@@ -143,8 +139,7 @@ if girder:
         """
         # Cache size is based on what the class needs, which does not include
         # individual tiles
-        cacheMaxSize = pickAvailableCache(1024 ** 2)
-        cacheTimeout = 300
+        cacheName = 'tilesource'
         name = 'pil'
 
         @staticmethod

--- a/server/tilesource/svs.py
+++ b/server/tilesource/svs.py
@@ -26,7 +26,7 @@ import openslide
 import PIL
 
 from .base import FileTileSource, TileSourceException
-from ..cache_util import LruCacheMetaclass, pickAvailableCache, methodcache
+from ..cache_util import LruCacheMetaclass, methodcache
 
 try:
     import girder
@@ -40,10 +40,7 @@ class SVSFileTileSource(FileTileSource):
     """
     Provides tile access to SVS files.
     """
-    # Cache size is based on what the class needs, which does not include
-    # individual tiles
-    cacheMaxSize = pickAvailableCache(1024 ** 2)
-    cacheTimeout = 300
+    cacheName = 'tilesource'
     name = 'svsfile'
 
     def __init__(self, path, **kwargs):
@@ -193,8 +190,5 @@ if girder:
         """
         Provides tile access to Girder items with an SVS file.
         """
-        # Cache size is based on what the class needs, which does not include
-        # individual tiles
-        cacheMaxSize = pickAvailableCache(1024 ** 2)
-        cacheTimeout = 300
+        cacheName = 'tilesource'
         name = 'svs'

--- a/server/tilesource/test.py
+++ b/server/tilesource/test.py
@@ -20,8 +20,7 @@
 import colorsys
 import six
 from .base import TileSource, TileSourceException
-from ..cache_util import strhash, methodcache, LruCacheMetaclass, \
-    pickAvailableCache
+from ..cache_util import strhash, methodcache, LruCacheMetaclass
 
 import PIL
 from PIL import Image, ImageDraw, ImageFont
@@ -35,8 +34,7 @@ tileCounter = 0
 
 @six.add_metaclass(LruCacheMetaclass)
 class TestTileSource(TileSource):
-    cacheMaxSize = pickAvailableCache(1024 ** 2)
-    cacheTimeout = 300
+    cacheName = 'tilesource'
     name = 'test'
 
     def __init__(self, ignored_path=None, minLevel=0, maxLevel=9,

--- a/server/tilesource/tiff.py
+++ b/server/tilesource/tiff.py
@@ -23,7 +23,7 @@ import six
 from six import BytesIO
 
 from .base import FileTileSource, TileSourceException
-from ..cache_util import pickAvailableCache, LruCacheMetaclass, methodcache
+from ..cache_util import LruCacheMetaclass, methodcache
 from .tiff_reader import TiledTiffDirectory, TiffException, \
     InvalidOperationTiffException, IOTiffException
 
@@ -46,10 +46,7 @@ class TiffFileTileSource(FileTileSource):
     """
     Provides tile access to TIFF files.
     """
-    # Cache size is based on what the class needs, which does not include
-    # individual tiles
-    cacheMaxSize = pickAvailableCache(1024 ** 2, 100)
-    cacheTimeout = 300
+    cacheName = 'tilesource'
     name = 'tifffile'
 
     def __init__(self, item, **kwargs):
@@ -133,8 +130,5 @@ if girder:
         """
         Provides tile access to Girder items with a TIFF file.
         """
-        # Cache size is based on what the class needs, which does not include
-        # individual tiles
-        cacheMaxSize = pickAvailableCache(1024 ** 2)
-        cacheTimeout = 300
+        cacheName = 'tilesource'
         name = 'tiff'


### PR DESCRIPTION
Prior to this, each tile source class used a separate cache.  This makes memory use difficult to manage intelligently.  The cache size needs to be set based on available file handles, as that is typically the limiting factor.  TIFF tile sources tend to have one open file handle per level of tiles, so the maximum number of tile sources that can be cached is now set based on that resource if it can be queried.  Moreover, ask to use more file handles if possible (it may not be).

Resolves issue #108.