### PR TITLE
Add an endpoint to clean up items with unfinished large_image jobs.

### DIFF
--- a/plugin_tests/large_image_test.py
+++ b/plugin_tests/large_image_test.py
@@ -21,7 +21,7 @@ import json
 import os
 import time
 
-from girder import config
+from girder import config, events
 from tests import base
 
 from . import common
@@ -195,3 +195,54 @@ class LargeImageLargeImageTest(common.LargeImageCommonTest):
         present, removed = self.model(
             'image_item', 'large_image').removeThumbnailFiles(item, keep=10)
         self.assertLess(present, 3 + len(slowList))
+
+    def testDeleteIncompleteTile(self):
+        # Test the large_image/settings end point
+        resp = self.request(
+            method='DELETE', path='/large_image/tiles/incomplete',
+            user=self.user)
+        self.assertStatus(resp, 403)
+        resp = self.request(
+            method='DELETE', path='/large_image/tiles/incomplete',
+            user=self.admin)
+        self.assertStatusOk(resp)
+        results = resp.json
+        self.assertEqual(results['removed'], 0)
+
+        file = self._uploadFile(os.path.join(
+            os.path.dirname(__file__), 'test_files', 'yb10kx5k.png'))
+        itemId = str(file['itemId'])
+        # Use a simulated cherrypy request, as it won't complete properly
+        resp = self.request(
+            method='POST', path='/item/%s/tiles' % itemId, user=self.admin)
+        resp = self.request(
+            method='DELETE', path='/large_image/tiles/incomplete',
+            user=self.admin)
+        self.assertStatusOk(resp)
+        results = resp.json
+        self.assertEqual(results['removed'], 1)
+
+        def preventCancel(evt):
+            evt.preventDefault()
+
+        # Prevent a job from cancelling
+        events.bind('jobs.cancel', 'testDeleteIncompleteTile', preventCancel)
+        resp = self.request(
+            method='POST', path='/item/%s/tiles' % itemId, user=self.admin)
+        resp = self.request(
+            method='DELETE', path='/large_image/tiles/incomplete',
+            user=self.admin)
+        self.assertStatusOk(resp)
+        results = resp.json
+        self.assertEqual(results['removed'], 0)
+        self.assertIn('could not be canceled', results['message'])
+        events.unbind('jobs.cancel', 'testDeleteIncompleteTile')
+        # Now we should be able to cancel the job
+        resp = self.request(
+            method='DELETE', path='/large_image/tiles/incomplete',
+            user=self.admin)
+        self.assertStatusOk(resp)
+        results = resp.json
+        self.assertEqual(results['removed'], 1)
+
+#

--- a/server/rest/large_image.py
+++ b/server/rest/large_image.py
@@ -90,6 +90,8 @@ class LargeImageResource(Resource):
         self.route('GET', ('thumbnails',), self.countThumbnails)
         self.route('PUT', ('thumbnails',), self.createThumbnails)
         self.route('DELETE', ('thumbnails',), self.deleteThumbnails)
+        self.route('DELETE', ('tiles', 'incomplete'),
+                   self.deleteIncompleteTiles)
 
     @describeRoute(
         Description('Count the number of cached thumbnail files for '
@@ -193,3 +195,34 @@ class LargeImageResource(Resource):
                 self.model('file').remove(file)
                 removed += 1
         return removed
+
+    @describeRoute(
+        Description('Remove large images from items where the large image job '
+                    'incomplete.')
+        .notes('This is used to clean up all large image conversion jobs that '
+               'have failed to complete.  If a job is in progress, it will be '
+               'cancelled.  The return value is the number of items that were '
+               'adjusted.')
+    )
+    @access.admin
+    def deleteIncompleteTiles(self, params):
+        itemModel = self.model('item')
+        imageItemModel = self.model('image_item', 'large_image')
+        jobModel = self.model('job', 'jobs')
+        result = {'removed': 0}
+        while True:
+            item = itemModel.findOne({'largeImage.expected': True})
+            if not item:
+                break
+            job = jobModel.load(item['largeImage']['jobId'], force=True)
+            if job and job.get('status') in (
+                    JobStatus.QUEUED, JobStatus.RUNNING):
+                job = jobModel.cancelJob(job)
+            if job and job.get('status') in (
+                    JobStatus.QUEUED, JobStatus.RUNNING):
+                result['message'] = ('The job for item %s could not be '
+                                     'canceled' % (str(item['_id'])))
+                break
+            imageItemModel.delete(item)
+            result['removed'] += 1
+        return result


### PR DESCRIPTION
If a large image job fails to complete (for instance, because Girder is restarted during the process, or the worker is not running), the item is marked as having a large image in progress, which prevents easily restarting the job.  This endpoint cleans up these states, cancelling any large_image job that is in progress or stuck.