### PR TITLE
Add JFIF to jpegs from ptifs

### DIFF
--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -245,7 +245,7 @@ class TiledTiffDirectory(object):
         # Strip the Start / End Of Image markers
         tableData = tableBuffer[2:tableSize - 2]
         # Add JFIF information to the header to keep iOS 10 happy
-        tableData = b'\xff\xe0\x00\x10JFIF\x00\x01\x01\x01\x00\x48\x00\x48\x00\x00' + tableData
+        tableData = b'\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00' + tableData
         return tableData
 
     def _toTileNum(self, x, y):

--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -244,6 +244,8 @@ class TiledTiffDirectory(object):
 
         # Strip the Start / End Of Image markers
         tableData = tableBuffer[2:tableSize - 2]
+        # Add JFIF information to the header to keep iOS 10 happy
+        tableData = b'\xff\xe0\x00\x10JFIF\x00\x01\x01\x01\x00\x48\x00\x48\x00\x00' + tableData
         return tableData
 
     def _toTileNum(self, x, y):


### PR DESCRIPTION
iOS 10.1 won't load a JPEGs without a JFIF record, even though it should be optional and ignored.