### PR TITLE
Support libtiff 4.0.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: python
 python:
   - "2.7"
 
+env:
+  - LIBTIFF_VERSION=4.0.3 OPENJPEG_VERSION=2.1   OPENJPEG_FILE=version.2.1.tar.gz OPENJPEG_DIR="openjpeg-version.2.1"
+  - LIBTIFF_VERSION=4.0.6 OPENJPEG_VERSION=2.1.2 OPENJPEG_FILE=v2.1.2.tar.gz      OPENJPEG_DIR="openjpeg-2.1.2"
+
 cache:
   directories:
     - $HOME/.cache
@@ -74,9 +78,9 @@ before_install:
   # There is an issue with the OpenJPEG library included with Ubuntu 14.04,
   # so install it from source.
   - cd $build_path
-  - wget -O openjpeg-2.1.tar.gz https://github.com/uclouvain/openjpeg/archive/version.2.1.tar.gz
-  - tar -zxf openjpeg-2.1.tar.gz
-  - cd openjpeg-version.2.1
+  - wget -O "openjpeg-$OPENJPEG_VERSION.tar.gz" "https://github.com/uclouvain/openjpeg/archive/$OPENJPEG_FILE"
+  - tar -zxf "openjpeg-$OPENJPEG_VERSION.tar.gz"
+  - cd "$OPENJPEG_DIR"
   # - wget -O openjpeg-1.5.2.tar.gz https://github.com/uclouvain/openjpeg/archive/version.1.5.2.tar.gz
   # - tar -zxf openjpeg-1.5.2.tar.gz
   # - cd openjpeg-version.1.5.2
@@ -88,9 +92,9 @@ before_install:
 
   # Build libtiff so it will use our openjpeg
   - cd $build_path
-  - wget http://download.osgeo.org/libtiff/tiff-4.0.3.tar.gz
-  - tar -zxf tiff-4.0.3.tar.gz
-  - cd tiff-4.0.3
+  - wget "http://download.osgeo.org/libtiff/tiff-$LIBTIFF_VERSION.tar.gz"
+  - tar -zxf "tiff-$LIBTIFF_VERSION.tar.gz"
+  - cd "tiff-$LIBTIFF_VERSION"
   - ./configure
   - make -j 3
   - sudo make install
@@ -127,6 +131,9 @@ before_install:
   - pip install --no-cache-dir -U pip virtualenv
 
   - pip install --no-cache-dir numpy==1.10.2  # needed because libtiff doesn't install correctly without it.  This ensures we have the same version for libtiff as for the project.
+
+  - if [ ${LIBTIFF_VERSION} == "4.0.6" ]; then pip install "git+https://github.com/pearu/pylibtiff@848785a6a9a4e2c6eb6f56ca9f7e8f6b32e523d5" --force-reinstal --ignore-installed --upgrade; fi
+
 
 install:
   - cd $girder_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,7 @@ Pillow>=3.2.0
 numpy>=1.10.2
 
 libtiff>=0.4.0
+# If you have OpenJPEG 2.1.1 or later or need libtiff 4.0.6 support, instead use
+# -e git+https://github.com/pearu/pylibtiff@848785a6a9a4e2c6eb6f56ca9f7e8f6b32e523d5
 
 openslide-python>=1.1.0

--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -133,6 +133,14 @@ class TiledTiffDirectory(object):
         except TypeError:
             raise IOTiffException(
                 'Could not open TIFF file: %s' % filePath)
+        # pylibtiff changed the case of some functions between version 0.4 and
+        # the version that supports libtiff 4.0.6.  To support both, ensure
+        # that the cased functions exist.
+        for func in ('SetDirectory', 'IsTiled', 'GetField'):
+            if (not hasattr(self._tiffFile, func) and
+                    hasattr(self._tiffFile, func.lower())):
+                setattr(self._tiffFile, func, getattr(
+                    self._tiffFile, func.lower()))
 
         self._directoryNum = directoryNum
         if self._tiffFile.SetDirectory(self._directoryNum) != 1:


### PR DESCRIPTION
If we use OpenJPEG 2.1.1 or later, it pulls in libtiff 4.0.6, in which case pylibtiff 0.4 no longer fully works.

Add support for pylibtiff's master branch.  This requires being case-agnostic for certain tiff file methods.