### PR TITLE
Fix a JPEG vips issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,13 +126,14 @@ before_install:
   - mongod --version
 
   - npm install -g npm
+  - npm install -g npm-install-retry
   - npm --version
 
   - pip install --no-cache-dir -U pip virtualenv
 
   - pip install --no-cache-dir numpy==1.10.2  # needed because libtiff doesn't install correctly without it.  This ensures we have the same version for libtiff as for the project.
 
-  - if [ ${LIBTIFF_VERSION} == "4.0.6" ]; then pip install "git+https://github.com/pearu/pylibtiff@848785a6a9a4e2c6eb6f56ca9f7e8f6b32e523d5" --force-reinstal --ignore-installed --upgrade; fi
+  - if [ ${LIBTIFF_VERSION} == "4.0.6" ]; then pip install "git+https://github.com/pearu/pylibtiff@848785a6a9a4e2c6eb6f56ca9f7e8f6b32e523d5" --force-reinstall --ignore-installed --upgrade; fi
 
 
 install:
@@ -140,7 +141,10 @@ install:
   - pip install --no-cache-dir -U -r requirements.txt -r requirements-dev.txt -e .
   - pip install -r $main_path/requirements.txt -e .
   - python -c "import openslide;print openslide.__version__"
-  - npm install
+  # This was
+  # - npm install
+  # but since there are often connection failures, use the retry package.
+  - npm-install-retry
 
 script:
   - cd $girder_worker_path

--- a/plugin_tests/common.py
+++ b/plugin_tests/common.py
@@ -29,9 +29,9 @@ from tests import base
 from girder.constants import SortDir
 
 
-JFIFHeader = '\xff\xd8\xff\xe0\x00\x10JFIF'
-JPEGHeader = '\xff\xd8\xff'
-PNGHeader = '\x89PNG'
+JFIFHeader = b'\xff\xd8\xff\xe0\x00\x10JFIF'
+JPEGHeader = b'\xff\xd8\xff'
+PNGHeader = b'\x89PNG'
 
 
 class LargeImageCommonTest(base.TestCase):

--- a/plugin_tests/common.py
+++ b/plugin_tests/common.py
@@ -29,6 +29,7 @@ from tests import base
 from girder.constants import SortDir
 
 
+JFIFHeader = '\xff\xd8\xff\xe0\x00\x10JFIF'
 JPEGHeader = '\xff\xd8\xff'
 PNGHeader = '\x89PNG'
 

--- a/plugin_tests/girderless_test.py
+++ b/plugin_tests/girderless_test.py
@@ -21,8 +21,8 @@ import math
 import os
 import unittest
 
-JPEGHeader = '\xff\xd8\xff'
-PNGHeader = '\x89PNG'
+JPEGHeader = b'\xff\xd8\xff'
+PNGHeader = b'\x89PNG'
 
 
 class LargeImageGirderlessTest(unittest.TestCase):

--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -94,6 +94,27 @@ class LargeImageTilesTest(common.LargeImageCommonTest):
         tileMetadata['sparse'] = 5
         self._testTilesZXY(itemId, tileMetadata)
 
+        # Check that we conditionally get JFIF headers
+        resp = self.request(path='/item/%s/tiles/zxy/0/0/0' % itemId,
+                            user=self.admin, isJson=False)
+        self.assertStatusOk(resp)
+        image = self.getBody(resp, text=False)
+        self.assertNotEqual(image[:len(common.JFIFHeader)], common.JFIFHeader)
+
+        resp = self.request(path='/item/%s/tiles/zxy/0/0/0' % itemId,
+                            user=self.admin, isJson=False,
+                            params={'encoding': 'JFIF'})
+        self.assertStatusOk(resp)
+        image = self.getBody(resp, text=False)
+        self.assertEqual(image[:len(common.JFIFHeader)], common.JFIFHeader)
+
+        resp = self.request(path='/item/%s/tiles/zxy/0/0/0' % itemId,
+                            user=self.admin, isJson=False,
+                            additionalHeaders=[('User-Agent', 'iPad')])
+        self.assertStatusOk(resp)
+        image = self.getBody(resp, text=False)
+        self.assertEqual(image[:len(common.JFIFHeader)], common.JFIFHeader)
+
         # Ask to make this a tile-based item again
         resp = self.request(path='/item/%s/tiles' % itemId, method='POST',
                             user=self.admin, params={'fileId': fileId})

--- a/server/create_tiff.py
+++ b/server/create_tiff.py
@@ -30,6 +30,8 @@ out_path = os.path.join(_tempdir, out_filename)
 
 convert_command = (
     'vips',
+    # '--vips-concurrency', '1',
+    # '--vips-progress',
     'tiffsave',
     in_path,
     out_path,
@@ -42,12 +44,20 @@ convert_command = (
     '--bigtiff'
 )
 
+try:
+    import six.moves
+    print('Command: %s' % (
+        ' '.join([six.moves.shlex_quote(arg) for arg in convert_command])))
+except ImportError:
+    pass
 proc = subprocess.Popen(convert_command, stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE)
 out, err = proc.communicate()
 
-if proc.returncode:
+if out.strip():
     print('stdout: ' + out)
+if err.strip():
     print('stderr: ' + err)
+if proc.returncode:
     raise Exception('VIPS command failed (rc=%d): %s' % (
         proc.returncode, ' '.join(convert_command)))

--- a/server/create_tiff.py
+++ b/server/create_tiff.py
@@ -30,8 +30,10 @@ out_path = os.path.join(_tempdir, out_filename)
 
 convert_command = (
     'vips',
-    # '--vips-concurrency', '1',
-    # '--vips-progress',
+    # Additional vips options can be added to aid debugging.  For instance,
+    #   '--vips-concurrency', '1',
+    #   '--vips-progress',
+    # can show how vips is processing a file.
     'tiffsave',
     in_path,
     out_path,

--- a/server/rest/tiles.py
+++ b/server/rest/tiles.py
@@ -31,6 +31,17 @@ from ..models import TileGeneralException
 from .. import loadmodelcache
 
 
+def _adjustParams(params):
+    try:
+        userAgent = cherrypy.request.headers.get('User-Agent', '').lower()
+    except Exception:
+        pass
+    if params.get('encoding', 'JPEG') == 'JPEG':
+        if ('ipad' in userAgent or 'ipod' in userAgent or
+                'iphone' in userAgent):
+            params['encoding'] = 'JFIF'
+
+
 class TilesItemResource(Item):
 
     def __init__(self, apiRoot):
@@ -92,6 +103,7 @@ class TilesItemResource(Item):
 
     @classmethod
     def _parseTestParams(cls, params):
+        _adjustParams(params)
         return cls._parseParams(params, False, [
             ('minLevel', int),
             ('maxLevel', int),
@@ -196,20 +208,9 @@ class TilesItemResource(Item):
         if x < 0 or y < 0 or z < 0:
             raise RestException('x, y, and z must be positive integers',
                                 code=400)
-        # In iOS 10.1, only JPEGs that have a JFIF header and read.  However,
-        # if we universally add a JFIF header, this breaks the colorspace
-        # parsing that browsers do on RGB-encoded JPEG (see
-        # https://docs.oracle.com/javase/8/docs/api/javax/imageio/metadata/
-        # doc-files/jpeg_metadata.html#color for a disuccsion on how colorspace
-        # is determined.  Since we would rather not reencode tiles if possible,
-        # we set a flag if we happen to be on an iOS device.  If the tile is a
-        # JPEG, then it will be parsed by PIL and reencoded.
-        userAgent = cherrypy.request.headers.get('User-Agent', '').lower()
-        alwaysConvertJPEG = ('ipad' in userAgent or 'ipod' in userAgent or
-                             'iphone' in userAgent)
         try:
             tileData, tileMime = self.imageItemModel.getTile(
-                item, x, y, z, alwaysConvertJPEG=alwaysConvertJPEG, **imageArgs)
+                item, x, y, z, **imageArgs)
         except TileGeneralException as e:
             raise RestException(e.message, code=404)
         setResponseHeader('Content-Type', tileMime)
@@ -238,6 +239,7 @@ class TilesItemResource(Item):
     #       return self._getTile(item, z, x, y, params)
     @access.public
     def getTile(self, itemId, z, x, y, params):
+        _adjustParams(params)
         item = loadmodelcache.loadModel(
             self, 'item', id=itemId, allowCookie=True, level=AccessType.READ)
         # Explicitly set a expires time to encourage browsers to cache this for
@@ -298,6 +300,7 @@ class TilesItemResource(Item):
     @access.public
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
     def getTilesThumbnail(self, item, params):
+        _adjustParams(params)
         params = self._parseParams(params, True, [
             ('width', int),
             ('height', int),
@@ -385,6 +388,7 @@ class TilesItemResource(Item):
     @access.public
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
     def getTilesRegion(self, item, params):
+        _adjustParams(params)
         params = self._parseParams(params, True, [
             ('left', float, 'region', 'left'),
             ('top', float, 'region', 'top'),

--- a/server/rest/tiles.py
+++ b/server/rest/tiles.py
@@ -32,6 +32,18 @@ from .. import loadmodelcache
 
 
 def _adjustParams(params):
+    """
+    Check the user agent of a request.  If it appears to be from an iOS device,
+    and the request is asking for JPEG encoding (or hasn't specified an
+    encoding), then make sure the output is JFIF.
+
+    It is unfortunate that this requires analyzing the user agent, as this
+    method if brittle.  However, other browsers can handle non-JFIF jpegs, and
+    we do not want to encur the overhead of conversion if it is not necessary
+    (converting to JFIF may require colorspace transforms).
+
+    :param params: the request parameters.  May be modified.
+    """
     try:
         userAgent = cherrypy.request.headers.get('User-Agent', '').lower()
     except Exception:

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -787,7 +787,9 @@ class TileSource(object):
             maxY = (y + 1) * self.tileHeight
             isEdge = maxX > sizeX or maxY > sizeY
         if tileEncoding != TILE_FORMAT_PIL:
-            if tileEncoding == self.encoding and not isEdge:
+            if (tileEncoding == self.encoding and not isEdge and
+                    (self.encoding != 'JPEG' or
+                     not kwargs.get('alwaysConvertJPEG'))):
                 return tile
             tile = PIL.Image.open(BytesIO(tile))
         if isEdge:

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -64,7 +64,9 @@ TILE_FORMAT_NUMPY = 'numpy'
 
 TileOutputMimeTypes = {
     # JFIF forces conversion to JPEG through PIL to ensure the image is in a
-    # common colorspace.
+    # common colorspace.  JPEG colorspace is complex: see
+    #   https://docs.oracle.com/javase/8/docs/api/javax/imageio/metadata/
+    #                           doc-files/jpeg_metadata.html
     'JFIF': 'image/jpeg',
     'JPEG': 'image/jpeg',
     'PNG': 'image/png'

--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -284,8 +284,6 @@ class TiledTiffDirectory(object):
 
         # Strip the Start / End Of Image markers
         tableData = tableBuffer[2:tableSize - 2]
-        # Add JFIF information to the header to keep iOS 10 happy
-        tableData = b'\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00' + tableData
         return tableData
 
     def _toTileNum(self, x, y):
@@ -484,11 +482,7 @@ class TiledTiffDirectory(object):
             # Write JPEG Start Of Image marker
             imageBuffer.write(b'\xff\xd8')
             imageBuffer.write(self._getJpegTables())
-            # TODO: why write padding?
-            imageBuffer.write(b'\xff\xff\xff\xff')
-
             imageBuffer.write(self._getJpegFrame(tileNum))
-
             # Write JPEG End Of Image marker
             imageBuffer.write(b'\xff\xd9')
             return imageBuffer.getvalue()


### PR DESCRIPTION
JFIF headers are now conditional.

See if an iOS is requesting a tile.  If so and we don't have a JFIF header, convert the JPEG to a PIL image and then to a new JPEG rather than adding a JFIF header.

It turns out that the colorspace of a JPEG is complicated, and adding a JFIF header changes it in unexpected ways.  See the comments.  vips (especially latest stable) often generates RGB jpegs (not YCbCr).  If you add a JFIF header to this, the colorspace is implied to be YCbCr, which is wrong.  Therefore, if we want to add a JFIF header, we *must* convert the colorspace, too.

Increase output from the create_tif script to make it easier to debug.   This print the actual command used and always prints non-empty stdout and stderr.
