### PR TITLE
Add try-except around metadata field load in tiff_reader

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -27,6 +27,7 @@ except ImportError as exc:
     if 'plugins' not in exc.message and 'girder' not in exc.message:
         raise
     import logging as logger
-    logger.info('Girder is unavailable.  Run as a girder plugin for girder '
-                'access.')
+    logger.getLogger().setLevel(logger.INFO)
+    logger.debug('Girder is unavailable.  Run as a girder plugin for girder '
+                 'access.')
     girder = None

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -676,10 +676,13 @@ class TileSource(object):
         format = iterInfo['format']
         encoding = iterInfo['encoding']
 
+        """
         logger.info(
             'Fetching region of an image with a source size of %d x %d; '
             'getting %d tiles',
             regionWidth, regionHeight, (xmax - xmin) * (ymax - ymin))
+        """
+
         # If tile is specified, return at most one tile
         if iterInfo.get('tile_position') is not None:
             tilePos = iterInfo.get('tile_position')

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -32,7 +32,7 @@ try:
     from girder.models.model_base import AccessType
 except ImportError:
     import logging as logger
-
+    logger.getLogger().setLevel(logger.INFO)
     girder = None
 
     class TileGeneralException(Exception):
@@ -676,12 +676,10 @@ class TileSource(object):
         format = iterInfo['format']
         encoding = iterInfo['encoding']
 
-        """
-        logger.info(
+        logger.debug(
             'Fetching region of an image with a source size of %d x %d; '
             'getting %d tiles',
             regionWidth, regionHeight, (xmax - xmin) * (ymax - ymin))
-        """
 
         # If tile is specified, return at most one tile
         if iterInfo.get('tile_position') is not None:

--- a/server/tilesource/svs.py
+++ b/server/tilesource/svs.py
@@ -35,6 +35,7 @@ try:
 except ImportError:
     girder = None
     import logging as logger
+    logger.getLogger().setLevel(logger.INFO)
 
 
 @six.add_metaclass(LruCacheMetaclass)

--- a/server/tilesource/tiff.py
+++ b/server/tilesource/tiff.py
@@ -35,6 +35,7 @@ try:
 except ImportError:
     girder = None
     import logging as logger
+    logger.getLogger().setLevel(logger.INFO)
 
 try:
     import PIL.Image

--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -225,9 +225,14 @@ class TiledTiffDirectory(object):
                   dir(libtiff_ctypes.tiff_h) if key.startswith('TIFFTAG_')]
         info = {}
         for field in fields:
-            value = self._tiffFile.GetField(field)
-            if value is not None:
-                info[field] = value
+            try:
+                value = self._tiffFile.GetField(field)
+                if value is not None:
+                    info[field] = value
+            except TypeError as err:
+                logger.debug('TypeError %s on loading field %s',
+                             err, field)
+
         for func in self.CoreFunctions[2:]:
             if hasattr(self._tiffFile, func):
                 value = getattr(self._tiffFile, func)()

--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -232,7 +232,7 @@ class TiledTiffDirectory(object):
             except TypeError as err:
                 logger.debug('Loading field %s in directory number %s '
                              'resulted in TypeError - %s',
-                             err, self._directoryNum, field)
+                             field, self._directoryNum, err)
 
         for func in self.CoreFunctions[2:]:
             if hasattr(self._tiffFile, func):

--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -31,6 +31,7 @@ try:
     from girder import logger
 except ImportError:
     import logging as logger
+    logger.getLogger().setLevel(logger.INFO)
 try:
     import PIL.Image
 except ImportError:
@@ -108,8 +109,8 @@ class TiledTiffDirectory(object):
 
         self._open(filePath, directoryNum)
         self._loadMetadata()
-        # logger.debug('TiffDirectory %d Information %r',
-        #              directoryNum, self._tiffInfo)
+        logger.debug('TiffDirectory %d Information %r',
+                     directoryNum, self._tiffInfo)
         try:
             self._validate()
         except ValidationTiffException:
@@ -230,8 +231,8 @@ class TiledTiffDirectory(object):
                 if value is not None:
                     info[field] = value
             except TypeError as err:
-                logger.debug('Loading field %s in directory number %s '
-                             'resulted in TypeError - %s',
+                logger.debug('Loading field "%s" in directory number %d '
+                             'resulted in TypeError - "%s"',
                              field, self._directoryNum, err)
 
         for func in self.CoreFunctions[2:]:

--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -109,7 +109,7 @@ class TiledTiffDirectory(object):
         self._open(filePath, directoryNum)
         self._loadMetadata()
         # logger.debug('TiffDirectory %d Information %r',
-        #             directoryNum, self._tiffInfo)
+        #              directoryNum, self._tiffInfo)
         try:
             self._validate()
         except ValidationTiffException:
@@ -230,8 +230,9 @@ class TiledTiffDirectory(object):
                 if value is not None:
                     info[field] = value
             except TypeError as err:
-                logger.debug('TypeError %s on loading field %s',
-                             err, field)
+                logger.debug('Loading field %s in directory number %s '
+                             'resulted in TypeError - %s',
+                             err, self._directoryNum, field)
 
         for func in self.CoreFunctions[2:]:
             if hasattr(self._tiffFile, func):

--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -108,8 +108,8 @@ class TiledTiffDirectory(object):
 
         self._open(filePath, directoryNum)
         self._loadMetadata()
-        logger.debug('TiffDirectory %d Information %r',
-                     directoryNum, self._tiffInfo)
+        # logger.debug('TiffDirectory %d Information %r',
+        #             directoryNum, self._tiffInfo)
         try:
             self._validate()
         except ValidationTiffException:


### PR DESCRIPTION
For some unknown field [self._tiffFile.GetField(field)](https://github.com/DigitalSlideArchive/large_image/blob/94db0233a21e2a9d466f6d413ece830392c4c0e2/server/tilesource/tiff_reader.py#L228) was throwing a TypeError when run in a distributed fashion on a cluster using Dask.